### PR TITLE
Atualiza uso do logo claro e padroniza dimensões

### DIFF
--- a/src/app/account/auth/lockscreen/basic/basic.component.html
+++ b/src/app/account/auth/lockscreen/basic/basic.component.html
@@ -18,7 +18,7 @@
                     <div class="text-center mt-sm-5 mb-4 text-white-50">
                         <div>
                             <a routerLink="" class="d-inline-block auth-logo">
-                                <img src="assets/images/logo-light.png" alt="" height="20">
+                                <img class="logo-img" src="https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png" alt="Servfarma">
                             </a>
                         </div>
                         <p class="mt-3 fs-15 fw-medium">Premium Admin & Dashboard Template</p>

--- a/src/app/account/auth/lockscreen/cover/cover.component.html
+++ b/src/app/account/auth/lockscreen/cover/cover.component.html
@@ -14,7 +14,7 @@
                                     <div class="position-relative h-100 d-flex flex-column">
                                         <div class="mb-4">
                                             <a routerLink="" class="d-block">
-                                                <img src="assets/images/logo-light.png" alt="" height="18">
+                                                <img class="logo-img" src="https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png" alt="Servfarma">
                                             </a>
                                         </div>
                                         <div class="mt-auto">

--- a/src/app/account/auth/logout/basic/basic.component.html
+++ b/src/app/account/auth/logout/basic/basic.component.html
@@ -18,7 +18,7 @@
                   <div class="text-center mt-sm-5 mb-4 text-white-50">
                       <div>
                           <a routerLink="" class="d-inline-block auth-logo">
-                              <img src="assets/images/logo-light.png" alt="" height="20">
+                              <img class="logo-img" src="https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png" alt="Servfarma">
                           </a>
                       </div>
                       <p class="mt-3 fs-15 fw-medium">Premium Admin & Dashboard Template</p>

--- a/src/app/account/auth/logout/cover/cover.component.html
+++ b/src/app/account/auth/logout/cover/cover.component.html
@@ -14,7 +14,7 @@
                                   <div class="position-relative h-100 d-flex flex-column">
                                       <div class="mb-4">
                                           <a routerLink="" class="d-block">
-                                              <img src="assets/images/logo-light.png" alt="" height="18">
+                                              <img class="logo-img" src="https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png" alt="Servfarma">
                                           </a>
                                       </div>
                                       <div class="mt-auto">

--- a/src/app/account/auth/pass-create/basic/basic.component.html
+++ b/src/app/account/auth/pass-create/basic/basic.component.html
@@ -18,7 +18,7 @@
                     <div class="text-center mt-sm-5 mb-4 text-white-50">
                         <div>
                             <a routerLink="/" class="d-inline-block auth-logo">
-                                <img src="assets/images/logo-light.png" alt="" height="20">
+                                <img class="logo-img" src="https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png" alt="Servfarma">
                             </a>
                         </div>
                         <p class="mt-3 fs-15 fw-medium">Premium Admin & Dashboard Template</p>

--- a/src/app/account/auth/pass-create/cover/cover.component.html
+++ b/src/app/account/auth/pass-create/cover/cover.component.html
@@ -14,7 +14,7 @@
                                     <div class="position-relative h-100 d-flex flex-column">
                                         <div class="mb-4">
                                             <a routerLink="" class="d-block">
-                                                <img src="assets/images/logo-light.png" alt="" height="18">
+                                                <img class="logo-img" src="https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png" alt="Servfarma">
                                             </a>
                                         </div>
                                         <div class="mt-auto">

--- a/src/app/account/auth/pass-reset/basic/basic.component.html
+++ b/src/app/account/auth/pass-reset/basic/basic.component.html
@@ -18,7 +18,7 @@
                     <div class="text-center mt-sm-5 mb-4 text-white-50">
                         <div>
                             <a routerLink="" class="d-inline-block auth-logo">
-                                <img src="assets/images/logo-light.png" alt="" height="20">
+                                <img class="logo-img" src="https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png" alt="Servfarma">
                             </a>
                         </div>
                         <p class="mt-3 fs-15 fw-medium">Premium Admin & Dashboard Template</p>

--- a/src/app/account/auth/pass-reset/cover/cover.component.html
+++ b/src/app/account/auth/pass-reset/cover/cover.component.html
@@ -14,7 +14,7 @@
                                     <div class="position-relative h-100 d-flex flex-column">
                                         <div class="mb-4">
                                             <a routerLink="" class="d-block">
-                                                <img src="assets/images/logo-light.png" alt="" height="18">
+                                                <img class="logo-img" src="https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png" alt="Servfarma">
                                             </a>
                                         </div>
                                         <div class="mt-auto">

--- a/src/app/account/auth/signin/basic/basic.component.html
+++ b/src/app/account/auth/signin/basic/basic.component.html
@@ -18,7 +18,7 @@
                     <div class="text-center mt-sm-5 mb-4 text-white-50">
                         <div>
                             <a routerLink="" class="d-inline-block auth-logo">
-                                <img src="assets/images/logo-light.png" alt="" height="20">
+                                <img class="logo-img" src="https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png" alt="Servfarma">
                             </a>
                         </div>
                         <p class="mt-3 fs-15 fw-medium">Premium Admin & Dashboard Template</p>

--- a/src/app/account/auth/signin/cover/cover.component.html
+++ b/src/app/account/auth/signin/cover/cover.component.html
@@ -14,7 +14,7 @@
                                     <div class="position-relative h-100 d-flex flex-column">
                                         <div class="mb-4">
                                             <a routerLink="" class="d-block">
-                                                <img src="assets/images/logo-light.png" alt="" height="18">
+                                                <img class="logo-img" src="https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png" alt="Servfarma">
                                             </a>
                                         </div>
                                         <div class="mt-auto">

--- a/src/app/account/auth/signup/basic/basic.component.html
+++ b/src/app/account/auth/signup/basic/basic.component.html
@@ -18,7 +18,7 @@
                   <div class="text-center mt-sm-5 mb-4 text-white-50">
                       <div>
                           <a routerLink="" class="d-inline-block auth-logo">
-                              <img src="assets/images/logo-light.png" alt="" height="20">
+                              <img class="logo-img" src="https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png" alt="Servfarma">
                           </a>
                       </div>
                       <p class="mt-3 fs-15 fw-medium">Premium Admin & Dashboard Template</p>

--- a/src/app/account/auth/signup/cover/cover.component.html
+++ b/src/app/account/auth/signup/cover/cover.component.html
@@ -14,7 +14,7 @@
                                   <div class="position-relative h-100 d-flex flex-column">
                                       <div class="mb-4">
                                           <a routerLink="" class="d-block">
-                                              <img src="assets/images/logo-light.png" alt="" height="18">
+                                              <img class="logo-img" src="https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png" alt="Servfarma">
                                           </a>
                                       </div>
                                       <div class="mt-auto">

--- a/src/app/account/auth/success-msg/basic/basic.component.html
+++ b/src/app/account/auth/success-msg/basic/basic.component.html
@@ -18,7 +18,7 @@
                   <div class="text-center mt-sm-5 mb-4 text-white-50">
                       <div>
                           <a routerLink="" class="d-inline-block auth-logo">
-                              <img src="assets/images/logo-light.png" alt="" height="20">
+                              <img class="logo-img" src="https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png" alt="Servfarma">
                           </a>
                       </div>
                       <p class="mt-3 fs-15 fw-medium">Premium Admin & Dashboard Template</p>

--- a/src/app/account/auth/success-msg/cover/cover.component.html
+++ b/src/app/account/auth/success-msg/cover/cover.component.html
@@ -14,7 +14,7 @@
                                   <div class="position-relative h-100 d-flex flex-column">
                                       <div class="mb-4">
                                           <a routerLink="" class="d-block">
-                                              <img src="assets/images/logo-light.png" alt="" height="18">
+                                              <img class="logo-img" src="https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png" alt="Servfarma">
                                           </a>
                                       </div>
                                       <div class="mt-auto">

--- a/src/app/account/auth/twostep/basic/basic.component.html
+++ b/src/app/account/auth/twostep/basic/basic.component.html
@@ -18,7 +18,7 @@
                   <div class="text-center mt-sm-5 mb-4 text-white-50">
                       <div>
                           <a routerLink="" class="d-inline-block auth-logo">
-                              <img src="assets/images/logo-light.png" alt="" height="20">
+                              <img class="logo-img" src="https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png" alt="Servfarma">
                           </a>
                       </div>
                       <p class="mt-3 fs-15 fw-medium">Premium Admin & Dashboard Template</p>

--- a/src/app/account/auth/twostep/cover/cover.component.html
+++ b/src/app/account/auth/twostep/cover/cover.component.html
@@ -14,7 +14,7 @@
                                   <div class="position-relative h-100 d-flex flex-column">
                                       <div class="mb-4">
                                           <a routerLink="" class="d-block">
-                                              <img src="assets/images/logo-light.png" alt="" height="18">
+                                              <img class="logo-img" src="https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png" alt="Servfarma">
                                           </a>
                                       </div>
                                       <div class="mt-auto">

--- a/src/app/account/login/login.component.html
+++ b/src/app/account/login/login.component.html
@@ -18,7 +18,7 @@
                     <div class="text-center mt-sm-5 mb-4 text-white-50">
                         <div>
                             <a href="javascript:void(0);" class="d-inline-block auth-logo">
-                                <img src="assets/images/logo-light.png" alt="" height="20">
+                                <img class="logo-img" src="https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png" alt="Servfarma">
                             </a>
                         </div>
                         <p class="mt-3 fs-15 fw-medium">Premium Admin & Dashboard Template</p>

--- a/src/app/account/register/register.component.html
+++ b/src/app/account/register/register.component.html
@@ -19,7 +19,7 @@
                     <div class="text-center mt-sm-5 mb-4 text-white-50">
                         <div>
                             <a href="javascript:void(0);" class="d-inline-block auth-logo">
-                                <img src="assets/images/logo-light.png" alt="" height="20">
+                                <img class="logo-img" src="https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png" alt="Servfarma">
                             </a>
                         </div>
                         <p class="mt-3 fs-15 fw-medium">Premium Admin & Dashboard Template</p>

--- a/src/app/landing/index/index.component.html
+++ b/src/app/landing/index/index.component.html
@@ -5,8 +5,7 @@
         <div class="container">
             <a class="navbar-brand" routerLink="/">
                 <img src="assets/images/logo-dark.png" class="card-logo card-logo-dark" alt="logo dark" height="17">
-                <img src="assets/images/logo-light.png" class="card-logo card-logo-light" alt="logo light"
-                    height="17">
+                <img src="https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png" class="card-logo card-logo-light logo-img" alt="Servfarma">
             </a>
             <button class="navbar-toggler py-0 fs-20 text-body" type="button" data-bs-toggle="collapse"
                 data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"

--- a/src/app/landing/job/job.component.html
+++ b/src/app/landing/job/job.component.html
@@ -6,8 +6,7 @@
             <div class="container-fluid custom-container">
                 <a class="navbar-brand" routerLink="">
                     <img src="assets/images/logo-dark.png" class="card-logo card-logo-dark" alt="logo dark" height="17">
-                    <img src="assets/images/logo-light.png" class="card-logo card-logo-light" alt="logo light"
-                        height="17">
+                    <img src="https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png" class="card-logo card-logo-light logo-img" alt="Servfarma">
                 </a>
                 <button class="navbar-toggler py-0 fs-20 text-body" type="button" data-bs-toggle="collapse"
                     data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"

--- a/src/app/landing/nft/nft.component.html
+++ b/src/app/landing/nft/nft.component.html
@@ -6,8 +6,7 @@
             <div class="container">
                 <a class="navbar-brand" routerLink="">
                     <img src="assets/images/logo-dark.png" class="card-logo card-logo-dark" alt="logo dark" height="17">
-                    <img src="assets/images/logo-light.png" class="card-logo card-logo-light" alt="logo light"
-                        height="17">
+                    <img src="https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png" class="card-logo card-logo-light logo-img" alt="Servfarma">
                 </a>
                 <button class="navbar-toggler py-0 fs-20 text-body" type="button" data-bs-toggle="collapse"
                     data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"

--- a/src/app/layouts/horizontal-topbar/horizontal-topbar.component.html
+++ b/src/app/layouts/horizontal-topbar/horizontal-topbar.component.html
@@ -16,7 +16,7 @@
                 <img src="assets/images/logo-sm.png" alt="" height="22">
             </span>
             <span class="logo-lg">
-                <img src="assets/images/logo-light.png" alt="" height="17">
+                <img src="https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png" alt="Servfarma" class="logo-img">
             </span>
         </a>
         <button type="button" class="btn btn-sm p-0 fs-20 header-item float-end btn-vertical-sm-hover" id="vertical-hover">

--- a/src/app/layouts/sidebar/sidebar.component.html
+++ b/src/app/layouts/sidebar/sidebar.component.html
@@ -17,7 +17,7 @@
         <img src="assets/images/logo-sm.png" alt="" height="22">
       </span>
       <span class="logo-lg">
-        <img src="assets/images/logo-light.png" alt="" height="17">
+        <img src="https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png" alt="Servfarma" class="logo-img">
       </span>
     </a>
     <button type="button" class="btn btn-sm p-0 fs-20 header-item float-end btn-vertical-sm-hover" id="vertical-hover">

--- a/src/app/layouts/topbar/topbar.component.html
+++ b/src/app/layouts/topbar/topbar.component.html
@@ -18,7 +18,7 @@
                             <img src="assets/images/logo-sm.png" alt="" height="22">
                         </span>
                         <span class="logo-lg">
-                            <img src="assets/images/logo-light.png" alt="" height="17">
+                            <img src="https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png" alt="Servfarma" class="logo-img">
                         </span>
                     </a>
                 </div>

--- a/src/app/layouts/two-column-sidebar/two-column-sidebar.component.html
+++ b/src/app/layouts/two-column-sidebar/two-column-sidebar.component.html
@@ -17,7 +17,7 @@
         <img src="assets/images/logo-sm.png" alt="" height="22">
       </span>
       <span class="logo-lg">
-        <img src="assets/images/logo-light.png" alt="" height="17">
+        <img src="https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png" alt="Servfarma" class="logo-img">
       </span>
     </a>
     <button type="button" class="btn btn-sm p-0 fs-20 header-item float-end btn-vertical-sm-hover" id="vertical-hover">

--- a/src/app/pages/advance-ui/scrollspy/scrollspy.component.html
+++ b/src/app/pages/advance-ui/scrollspy/scrollspy.component.html
@@ -24,7 +24,7 @@
                     <nav id="navbar-example" class="navbar navbar-dark bg-light px-3">
                         <a class="navbar-brand" href="javascript: void(0);">
                             <img src="assets/images/logo-dark.png" class="card-logo card-logo-dark" alt="logo dark" height="14">
-                            <img src="assets/images/logo-light.png" class="card-logo card-logo-light" alt="logo light" height="14">
+                            <img src="https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png" class="card-logo card-logo-light logo-img" alt="Servfarma">
                         </a>
                         <ul class="nav nav-pills">
                             <li class="nav-item">
@@ -100,7 +100,7 @@
                     <pre><code class="language-markup"> &lt;nav id=&quot;navbar-example&quot; class=&quot;navbar navbar-dark bg-light px-3&quot;&gt;
     &lt;a class=&quot;navbar-brand&quot; href=&quot;javascript: void(0);&quot;&gt;
         &lt;img src=&quot;assets/images/logo-dark.png&quot; class=&quot;card-logo card-logo-dark&quot; alt=&quot;logo dark&quot; height=&quot;14&quot;&gt;
-        &lt;img src=&quot;assets/images/logo-light.png&quot; class=&quot;card-logo card-logo-light&quot; alt=&quot;logo light&quot; height=&quot;14&quot;&gt;
+        &lt;img src=&quot;https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png&quot; class=&quot;card-logo card-logo-light logo-img&quot; alt=&quot;Servfarma&quot;&gt;
     &lt;/a&gt;
     &lt;ul class=&quot;nav nav-pills&quot;&gt;
         &lt;li class=&quot;nav-item&quot;&gt;
@@ -180,7 +180,7 @@
                             <nav id="navbar-examplenested" class="navbar navbar-dark bg-light flex-column">
                                 <a class="navbar-brand mb-2" href="javascript:void(0);">
                                     <img src="assets/images/logo-dark.png" class="card-logo card-logo-dark" alt="logo dark" height="15">
-                                    <img src="assets/images/logo-light.png" class="card-logo card-logo-light" alt="logo light" height="15">
+                                    <img src="https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png" class="card-logo card-logo-light logo-img" alt="Servfarma">
                                 </a>
                                 <nav class="nav nav-pills flex-column p-3 w-100">
                                     <a class="nav-link" [ngClass]="{'active':currentSection === 'item-1'}" href="javascript:void(0);"><i class="ri-dashboard-2-line align-middle me-2 fs-16"></i>
@@ -299,7 +299,7 @@
 &lt;nav id=&quot;navbar-examplenested&quot; class=&quot;navbar navbar-dark bg-light flex-column&quot;&gt;
     &lt;a class=&quot;navbar-brand mb-2&quot; href=&quot;#&quot;&gt;
         &lt;img src=&quot;assets/images/logo-dark.png&quot; class=&quot;card-logo card-logo-dark&quot; alt=&quot;logo dark&quot; height=&quot;15&quot;&gt;
-        &lt;img src=&quot;assets/images/logo-light.png&quot; class=&quot;card-logo card-logo-light&quot; alt=&quot;logo light&quot; height=&quot;15&quot;&gt;
+        &lt;img src=&quot;https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png&quot; class=&quot;card-logo card-logo-light logo-img&quot; alt=&quot;Servfarma&quot;&gt;
     &lt;/a&gt;
     &lt;nav class=&quot;nav nav-pills flex-column p-3 w-100&quot;&gt;
         &lt;a class=&quot;nav-link&quot; [ngClass]=&quot;&#0123;'active':currentSection === 'item-1'&#0125;&quot; href=&quot;javascript:void(0);&quot;&gt;&lt;i class=&quot;ri-dashboard-2-line align-middle me-2 fs-16&quot;&gt;&lt;/i&gt;

--- a/src/app/pages/advance-ui/tour/tour.component.html
+++ b/src/app/pages/advance-ui/tour/tour.component.html
@@ -21,7 +21,7 @@
                           <div class="text-center mt-4 mb-5">
                               <div class="py-3 px-2 d-inline-block actions" id="logo-tour">
                                   <img src="assets/images/logo-dark.png" class="card-logo card-logo-dark" alt="logo" height="17">
-                                  <img src="assets/images/logo-light.png" class="card-logo card-logo-light" alt="logo" height="17">
+                                  <img src="https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png" class="card-logo card-logo-light logo-img" alt="Servfarma">
                               </div>
                               <h5 class="fs-16">Responsive Admin Dashboard Template</h5>
                               <p class="text-muted">Vestibulum auctor tincidunt semper. Phasellus

--- a/src/app/pages/invoices/create/create.component.html
+++ b/src/app/pages/invoices/create/create.component.html
@@ -14,7 +14,7 @@
                                 <label for="profile-img-file-input" class="d-block" tabindex="0">
                                     <span class="overflow-hidden border border-dashed d-flex align-items-center justify-content-center rounded" style="height: 60px; width: 256px;">
                                         <img src="assets/images/logo-dark.png" class="card-logo card-logo-dark user-profile-image img-fluid" alt="logo dark">
-                                        <img src="assets/images/logo-light.png" class="card-logo card-logo-light user-profile-image img-fluid" alt="logo light">
+                                        <img src="https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png" class="card-logo card-logo-light user-profile-image img-fluid logo-img" alt="Servfarma">
                                     </span>
                                 </label>
                             </div>

--- a/src/app/pages/invoices/details/details.component.html
+++ b/src/app/pages/invoices/details/details.component.html
@@ -12,8 +12,8 @@
                             <div class="flex-grow-1">
                                 <img src="assets/images/logo-dark.png" class="card-logo card-logo-dark" alt="logo dark"
                                     height="17">
-                                <img src="assets/images/logo-light.png" class="card-logo card-logo-light"
-                                    alt="logo light" height="17">
+                                <img src="https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png" class="card-logo card-logo-light logo-img"
+                                    alt="Servfarma">
                                 <div class="mt-sm-5 mt-4">
                                     <h6 class="text-muted text-uppercase fw-semibold">Address</h6>
                                     <p class="text-muted mb-1" id="address-details">California, United States</p>

--- a/src/app/shared/landing/index/footer/footer.component.html
+++ b/src/app/shared/landing/index/footer/footer.component.html
@@ -5,7 +5,7 @@
             <div class="col-lg-4 mt-4">
                 <div>
                     <div>
-                        <img src="assets/images/logo-light.png" alt="logo light" height="17">
+                        <img class="logo-img" src="https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png" alt="Servfarma">
                     </div>
                     <div class="mt-4 fs-13">
                         <p>Premium Multipurpose Admin & Dashboard Template</p>

--- a/src/app/shared/landing/job/job-footer/job-footer.component.html
+++ b/src/app/shared/landing/job/job-footer/job-footer.component.html
@@ -5,7 +5,7 @@
             <div class="col-lg-4 mt-4">
                 <div>
                     <div>
-                        <img src="assets/images/logo-light.png" alt="logo light" height="17" />
+                        <img class="logo-img" src="https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png" alt="Servfarma" />
                     </div>
                     <div class="mt-4 fs-13">
                         <p>Premium Multipurpose Admin & Dashboard Template</p>

--- a/src/assets/scss/components/_helper.scss
+++ b/src/assets/scss/components/_helper.scss
@@ -261,6 +261,25 @@ code {
     display: var(--#{$prefix}card-logo-light);
 }
 
+.logo-img {
+    max-height: 40px;
+    height: auto;
+    width: auto;
+}
+
+.logo .logo-img {
+    max-height: 36px;
+}
+
+.auth-logo .logo-img {
+    max-height: 48px;
+}
+
+.card-logo.logo-img,
+.card-logo-light.logo-img {
+    max-height: 28px;
+}
+
 .card-logo-dark {
     display: var(--#{$prefix}card-logo-dark);
 }


### PR DESCRIPTION
## Summary
- substitui todas as referências ao logo claro para usar o novo arquivo hospedado em https://hml-accounts.servfarma.com.br/resources/oa6ev/login/servfarma/img/logo.png nas barras, layouts, telas de autenticação e páginas de marketing
- adiciona a classe utilitária `.logo-img` com limites de altura específicos para topo, cartões e fluxos de autenticação garantindo que o novo logo mantenha proporções adequadas

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd747f37ec832f835427049f12be0b