### PR TITLE
Fix permission directive usage on user list buttons

### DIFF
--- a/src/app/pages/user-management/users/user-list.component.html
+++ b/src/app/pages/user-management/users/user-list.component.html
@@ -8,7 +8,12 @@
           <h5 class="card-title mb-1">Usuarios</h5>
           <p class="text-muted mb-0">Gerencie o acesso dos usuarios e seus perfis.</p>
         </div>
-        <button type="button" class="btn btn-primary" (click)="createUser()" appHasPermission="user:write">
+        <button
+          type="button"
+          class="btn btn-primary"
+          (click)="createUser()"
+          *appHasPermission="'user:write'"
+        >
           <i class="ri-user-add-line align-middle me-1"></i>
           Novo usuario
         </button>
@@ -66,7 +71,12 @@
                   }
                 </td>
                 <td class="text-end">
-                  <button type="button" class="btn btn-sm btn-outline-primary" (click)="editUser(user)" appHasPermission="user:write">
+                  <button
+                    type="button"
+                    class="btn btn-sm btn-outline-primary"
+                    (click)="editUser(user)"
+                    *appHasPermission="'user:write'"
+                  >
                     <i class="ri-edit-line align-middle"></i>
                     <span class="ms-1">Editar</span>
                   </button>


### PR DESCRIPTION
## Summary
- switch the user list actions to use the structural permission directive syntax so the buttons render only when allowed

## Testing
- npm run build *(fails: cannot inline Google Fonts due to 403 response)*

------
https://chatgpt.com/codex/tasks/task_e_68ddd9d842b0832f8cc7e8d8daae8f0c