### PR TITLE
Restore topbar dropdown avatar styling

### DIFF
--- a/src/app/layouts/topbar/topbar.component.html
+++ b/src/app/layouts/topbar/topbar.component.html
@@ -45,12 +45,21 @@
                       ngbDropdownToggle
                     >
                         <span class="d-flex align-items-center">
-                            <span class="header-profile-user bg-primary-subtle text-primary fw-semibold rounded-circle">
-                                {{ userInitial }}
-                            </span>
+                            <ng-container *ngIf="!showInitials; else initialsAvatar">
+                                <img
+                                  [src]="userAvatarUrl || defaultAvatarUrl"
+                                  class="rounded-circle header-profile-user"
+                                  [alt]="userName || 'Usuario'"
+                                />
+                            </ng-container>
+                            <ng-template #initialsAvatar>
+                                <span class="avatar-title rounded-circle header-profile-user bg-primary-subtle text-primary fw-semibold">
+                                    {{ userInitial }}
+                                </span>
+                            </ng-template>
                             <span class="text-start ms-2 d-none d-xl-block">
-                                <span class="d-block fw-medium text-body">{{ userName || 'Usuario' }}</span>
-                                <span class="d-block text-muted fs-12">{{ userRoleLabel }}</span>
+                                <span class="d-block fw-medium text-body user-name-text">{{ userName || 'Usuario' }}</span>
+                                <span class="d-block text-muted fs-12 user-name-sub-text">{{ userRoleLabel }}</span>
                             </span>
                         </span>
                     </button>

--- a/src/app/layouts/topbar/topbar.component.scss
+++ b/src/app/layouts/topbar/topbar.component.scss
@@ -1,10 +1,19 @@
-.topbar-user .header-profile-user {
-  width: 36px;
-  height: 36px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 0.95rem;
+.topbar-user {
+  .header-profile-user {
+    width: 36px;
+    height: 36px;
+  }
+
+  img.header-profile-user {
+    object-fit: cover;
+  }
+
+  .avatar-title.header-profile-user {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.95rem;
+  }
 }
 
 .topbar-user .dropdown-toggle {


### PR DESCRIPTION
## Summary
- restore the topbar dropdown markup so it shows the rounded avatar image when present while keeping the existing user details layout
- add avatar resolution logic with graceful fallbacks to initials or the default placeholder image to maintain the original appearance

## Testing
- Not run (not available in environment)

------
https://chatgpt.com/codex/tasks/task_e_68e1258ee72c832fa05423ec2255413b