### PR TITLE
Refine bank list state management

### DIFF
--- a/src/app/core/http/case-convert.utils.ts
+++ b/src/app/core/http/case-convert.utils.ts
@@ -1,10 +1,9 @@
-
 /** Simple helpers to convert between camelCase <-> snake_case recursively */
 
 const toCamel = (s: string) =>
   s.replace(/[_-](\w)/g, (_, c) => (c ? c.toUpperCase() : ''));
 
-const toSnake = (s: string) =>
+export const toSnakeCase = (s: string) =>
   s
     .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
     .replace(/[-\s]+/g, '_')
@@ -29,7 +28,7 @@ export function keysToSnakeCase<T = any>(input: any): T {
     const result: any = {};
     Object.keys(input).forEach((k) => {
       const v = (input as any)[k];
-      result[toSnake(k)] = keysToSnakeCase(v);
+      result[toSnakeCase(k)] = keysToSnakeCase(v);
     });
     return result;
   }

--- a/src/app/feature-module/administration/banks/bank-upsert/bank-upsert.component.ts
+++ b/src/app/feature-module/administration/banks/bank-upsert/bank-upsert.component.ts
@@ -17,15 +17,13 @@ import {
 import { ValidationErrorsBannerComponent } from '../../../../core/notifications/validation-errors-banner.component';
 import { SharedModule } from '../../../../shared/shared.module';
 import { applyServerValidationErrors } from '../../../../shared/common/server-validation.util';
-import {
-  BanksApiService,
-  CreateBankDto,
-  UpdateBankDto,
-} from '../services/banks.api.service';
+import { BanksApiService } from '../services/banks.api.service';
 import { BanksStateService } from '../services/banks-state.service';
 import {
   BankDetailsViewModel,
   BankViewModel,
+  CreateBankPayload,
+  UpdateBankPayload,
 } from '../../../../shared/models/banks';
 
 @Component({
@@ -129,7 +127,7 @@ export class BankUpsertComponent implements OnInit {
     this.isSaving.set(true);
 
     if (this.id()) {
-      const dto: UpdateBankDto = {
+      const dto: UpdateBankPayload = {
         name: value.name,
         bankCode: value.bankCode,
         isActive: value.isActive,
@@ -143,7 +141,7 @@ export class BankUpsertComponent implements OnInit {
         error: failure,
       });
     } else {
-      const dto: CreateBankDto = {
+      const dto: CreateBankPayload = {
         name: value.name,
         bankCode: value.bankCode,
         isActive: value.isActive,

--- a/src/app/feature-module/administration/banks/banks/banks.component.html
+++ b/src/app/feature-module/administration/banks/banks/banks.component.html
@@ -103,46 +103,46 @@
                 <th
                   scope="col"
                   class="sort"
-                  (click)="toggleSort('Name')"
-                  (keydown.enter)="toggleSort('Name')"
+                  (click)="toggleSort('name')"
+                  (keydown.enter)="toggleSort('name')"
                   role="button"
                   tabindex="0"
                 >
                   Nome
-                  <span class="sort-icon"><i *ngIf="orderLabel === 'Name'" class="ti" [ngClass]="ascending ? 'ti-arrow-up' : 'ti-arrow-down'"></i></span>
+                  <span class="sort-icon"><i *ngIf="orderBy === 'name'" class="ti" [ngClass]="ascending ? 'ti-arrow-up' : 'ti-arrow-down'"></i></span>
                 </th>
                 <th
                   scope="col"
                   class="sort"
-                  (click)="toggleSort('BankCode')"
-                  (keydown.enter)="toggleSort('BankCode')"
+                  (click)="toggleSort('bankCode')"
+                  (keydown.enter)="toggleSort('bankCode')"
                   role="button"
                   tabindex="0"
                 >
                   Codigo
-                  <span class="sort-icon"><i *ngIf="orderLabel === 'BankCode'" class="ti" [ngClass]="ascending ? 'ti-arrow-up' : 'ti-arrow-down'"></i></span>
+                  <span class="sort-icon"><i *ngIf="orderBy === 'bankCode'" class="ti" [ngClass]="ascending ? 'ti-arrow-up' : 'ti-arrow-down'"></i></span>
                 </th>
                 <th
                   scope="col"
                   class="sort"
-                  (click)="toggleSort('CreatedDate')"
-                  (keydown.enter)="toggleSort('CreatedDate')"
+                  (click)="toggleSort('createdAt')"
+                  (keydown.enter)="toggleSort('createdAt')"
                   role="button"
                   tabindex="0"
                 >
                   Criado em
-                  <span class="sort-icon"><i *ngIf="orderLabel === 'CreatedDate'" class="ti" [ngClass]="ascending ? 'ti-arrow-up' : 'ti-arrow-down'"></i></span>
+                  <span class="sort-icon"><i *ngIf="orderBy === 'createdAt'" class="ti" [ngClass]="ascending ? 'ti-arrow-up' : 'ti-arrow-down'"></i></span>
                 </th>
                 <th
                   scope="col"
                   class="sort"
-                  (click)="toggleSort('Status')"
-                  (keydown.enter)="toggleSort('Status')"
+                  (click)="toggleSort('isActive')"
+                  (keydown.enter)="toggleSort('isActive')"
                   role="button"
                   tabindex="0"
                 >
                   Status
-                  <span class="sort-icon"><i *ngIf="orderLabel === 'Status'" class="ti" [ngClass]="ascending ? 'ti-arrow-up' : 'ti-arrow-down'"></i></span>
+                  <span class="sort-icon"><i *ngIf="orderBy === 'isActive'" class="ti" [ngClass]="ascending ? 'ti-arrow-up' : 'ti-arrow-down'"></i></span>
                 </th>
                 <th scope="col" class="text-end">Acoes</th>
               </tr>

--- a/src/app/feature-module/administration/banks/banks/banks.component.ts
+++ b/src/app/feature-module/administration/banks/banks/banks.component.ts
@@ -1,8 +1,18 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { finalize } from 'rxjs/operators';
 import { BanksApiService } from '../services/banks.api.service';
 import { BanksStateService } from '../services/banks-state.service';
-import { BankViewModel } from '../../../../shared/models/banks';
+import {
+  BankListFilterState,
+  BankSortableField,
+  BankViewModel,
+  ListBanksParams,
+  defaultBankListFilterState,
+  normalizeBankListFilters,
+} from '../../../../shared/models/banks';
 import { PaginationService } from '../../../../shared/custom-pagination/pagination.service';
+import { BanksListViewState } from '../services/banks-state.service';
 
 @Component({
   selector: 'app-banks',
@@ -18,146 +28,105 @@ export class BanksComponent implements OnInit {
   tableData: BankViewModel[] = [];
 
   pageSize = 10;
-  backendPage = 1;
+  currentPage = 1;
   totalItems = 0;
 
   filtroNome = '';
   filtroCodigo = '';
   filtroAtivo: '' | 'true' | 'false' = '';
 
-  orderBy: string = 'created_at';
-  ascending: boolean = false;
-  orderLabel: 'CreatedDate' | 'Name' | 'BankCode' | 'Status' = 'CreatedDate';
+  orderBy: BankSortableField = 'createdAt';
+  ascending = false;
 
   carregando = false;
   private lastPagerKey = '';
   private lastRequestSignature = '';
-  private allowPagerUpdates = false;
+  private suppressPagerSync = true;
+  private readonly destroyRef = inject(DestroyRef);
 
   constructor(
     private api: BanksApiService,
     private pagination: PaginationService,
     private banksState: BanksStateService,
   ) {
-    this.pagination.tablePageSize.subscribe(({ skip, limit, pageSize }) => {
-      if (!this.allowPagerUpdates) {
-        return;
-      }
-      const size = (typeof pageSize === 'number' && pageSize > 0) ? pageSize : this.pageSize || 10;
-      const newPage = Math.floor((typeof skip === 'number' ? skip : 0) / size) + 1;
-      const pagerKey = `${newPage}|${size}`;
-      if (pagerKey === this.lastPagerKey) {
-        return;
-      }
-      this.lastPagerKey = pagerKey;
-      this.pageSize = size;
-      this.backendPage = newPage;
-      this.loadPage();
-    });
+    this.pagination.tablePageSize
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(({ skip, pageSize }) => {
+        if (this.suppressPagerSync) {
+          return;
+        }
+
+        const normalizedPageSize =
+          typeof pageSize === 'number' && pageSize > 0 ? pageSize : this.pageSize || 10;
+        const normalizedSkip = typeof skip === 'number' && skip >= 0 ? skip : 0;
+        const newPage = Math.floor(normalizedSkip / normalizedPageSize) + 1;
+        const pagerKey = `${newPage}|${normalizedPageSize}`;
+        if (pagerKey === this.lastPagerKey) {
+          return;
+        }
+
+        this.applyPaginationChange(newPage, normalizedPageSize);
+        this.loadPage();
+      });
   }
 
   ngOnInit(): void {
     const savedState = this.banksState.getListState();
+
+    this.suppressPagerSync = true;
     if (savedState) {
-      this.totalItems = savedState.totalItems;
-      this.pageSize = savedState.pageSize;
-      this.backendPage = savedState.backendPage;
-      this.filtroNome = savedState.filtroNome;
-      this.filtroCodigo = savedState.filtroCodigo;
-      this.filtroAtivo = savedState.filtroAtivo;
-      this.orderBy = savedState.orderBy;
-      this.ascending = savedState.ascending;
-      this.orderLabel = savedState.orderLabel;
-      this.tableData = savedState.tableData;
-      this.lastRequestSignature = savedState.lastRequestSignature ?? '';
-      this.lastPagerKey = savedState.lastPagerKey ?? `${this.backendPage}|${this.pageSize}`;
-      this.pagination.calculatePageSize.next({
-        totalData: this.totalItems,
-        pageSize: this.pageSize,
-        tableData: this.tableData,
-        serialNumberArray: [],
-      });
-      this.pagination.tablePageSize.next({
-        skip: (this.backendPage - 1) * this.pageSize,
-        limit: this.backendPage * this.pageSize,
-        pageSize: this.pageSize,
-      });
-      this.allowPagerUpdates = true;
-      return;
-    }
-
-    this.allowPagerUpdates = true;
-    this.pagination.calculatePageSize.next({
-      totalData: this.totalItems,
-      pageSize: this.pageSize,
-      tableData: [],
-      serialNumberArray: [],
-    });
-    this.loadPage();
-  }
-
-  private mapOrderField(field: string): string {
-    switch (field) {
-      case 'CreatedDate':
-        return 'created_at';
-      case 'Name':
-        return 'name';
-      case 'BankCode':
-        return 'bank_code';
-      case 'Status':
-        return 'active';
-      default:
-        return 'created_at';
-    }
-  }
-
-  toggleSort(field: 'CreatedDate' | 'Name' | 'BankCode' | 'Status') {
-    if (this.orderLabel === field) {
-      this.ascending = !this.ascending;
+      this.applyPersistedState(savedState);
     } else {
-      this.orderLabel = field;
-      this.ascending = true;
+      this.resetFilters();
+      this.emitPaginationSnapshot();
     }
-    this.orderBy = this.mapOrderField(this.orderLabel);
-    this.backendPage = 1;
+    this.suppressPagerSync = false;
+
+    if (!savedState) {
+      this.loadPage();
+    }
+  }
+
+  toggleSort(field: BankSortableField) {
+    this.ascending = this.orderBy === field ? !this.ascending : true;
+    this.orderBy = field;
+    this.currentPage = 1;
     this.loadPage();
   }
 
   changePageSize(size: number) {
     this.pageSize = Number(size) || 10;
-    this.backendPage = 1;
+    this.currentPage = 1;
     this.pagination.tablePageSize.next({
-      skip: (this.backendPage - 1) * this.pageSize,
-      limit: this.backendPage * this.pageSize,
+      skip: (this.currentPage - 1) * this.pageSize,
+      limit: this.currentPage * this.pageSize,
       pageSize: this.pageSize,
     });
   }
 
   aplicarFiltros() {
-    this.backendPage = 1;
+    this.currentPage = 1;
     this.loadPage();
   }
 
   limparFiltros() {
-    this.filtroNome = '';
-    this.filtroCodigo = '';
-    this.filtroAtivo = '';
-    this.backendPage = 1;
+    this.setFilters(defaultBankListFilterState);
+    this.currentPage = 1;
     this.loadPage();
   }
 
   private loadPage() {
     this.carregando = true;
-    this.lastPagerKey = `${this.backendPage}|${this.pageSize}`;
-    const params: any = {
-      page: this.backendPage,
+    this.lastPagerKey = `${this.currentPage}|${this.pageSize}`;
+
+    const filterState = this.captureFilters();
+    const params: ListBanksParams = {
+      page: this.currentPage,
       pageSize: this.pageSize,
       orderBy: this.orderBy,
       ascending: this.ascending,
+      ...normalizeBankListFilters(filterState),
     };
-    if (this.filtroNome) params.name = this.filtroNome;
-    if (this.filtroCodigo) params.bankCode = this.filtroCodigo;
-    if (this.filtroAtivo !== '') params.isActive = this.filtroAtivo === 'true';
 
     const signature = JSON.stringify(params);
     if (signature === this.lastRequestSignature) {
@@ -166,36 +135,85 @@ export class BanksComponent implements OnInit {
     }
     this.lastRequestSignature = signature;
 
-    this.api.list(params).subscribe({
-      next: (res) => {
-        this.totalItems = res.totalCount ?? 0;
-        this.tableData = res.items || [];
-        this.banksState.setMany(this.tableData);
-        this.banksState.setListState({
-          tableData: this.tableData,
-          totalItems: this.totalItems,
-          pageSize: this.pageSize,
-          backendPage: this.backendPage,
-          filtroNome: this.filtroNome,
-          filtroCodigo: this.filtroCodigo,
-          filtroAtivo: this.filtroAtivo,
-          orderBy: this.orderBy,
-          ascending: this.ascending,
-          orderLabel: this.orderLabel,
-          lastRequestSignature: this.lastRequestSignature,
-          lastPagerKey: this.lastPagerKey,
-        });
-        this.pagination.calculatePageSize.next({
-          totalData: this.totalItems,
-          pageSize: this.pageSize,
-          tableData: this.tableData,
-          serialNumberArray: [],
-        });
-        this.carregando = false;
-      },
-      error: () => {
-        this.carregando = false;
-      },
+    this.api
+      .list(params)
+      .pipe(finalize(() => (this.carregando = false)))
+      .subscribe({
+        next: (res) => {
+          this.totalItems = res.totalCount ?? 0;
+          this.tableData = res.items || [];
+          this.banksState.setMany(this.tableData);
+          this.persistListState(filterState);
+          this.emitPaginationSnapshot();
+        },
+        error: () => {
+          this.lastRequestSignature = '';
+        },
+      });
+  }
+
+  private applyPersistedState(state: BanksListViewState): void {
+    this.tableData = state.items;
+    this.totalItems = state.totalItems;
+    this.pageSize = state.pageSize;
+    this.currentPage = state.page;
+    this.orderBy = state.orderBy;
+    this.ascending = state.ascending;
+    this.lastRequestSignature = state.lastRequestSignature ?? '';
+    this.lastPagerKey = state.lastPagerKey ?? `${state.page}|${state.pageSize}`;
+    this.setFilters(state.filters);
+    this.emitPaginationSnapshot();
+    this.pagination.tablePageSize.next({
+      skip: (this.currentPage - 1) * this.pageSize,
+      limit: this.currentPage * this.pageSize,
+      pageSize: this.pageSize,
+    });
+  }
+
+  private applyPaginationChange(page: number, size: number): void {
+    this.currentPage = page;
+    this.pageSize = size;
+    this.lastPagerKey = `${page}|${size}`;
+  }
+
+  private captureFilters(): BankListFilterState {
+    return {
+      name: this.filtroNome,
+      bankCode: this.filtroCodigo,
+      isActive: this.filtroAtivo,
+    };
+  }
+
+  private setFilters(filters: BankListFilterState): void {
+    this.filtroNome = filters.name;
+    this.filtroCodigo = filters.bankCode;
+    this.filtroAtivo = filters.isActive;
+  }
+
+  private resetFilters(): void {
+    this.setFilters(defaultBankListFilterState);
+  }
+
+  private emitPaginationSnapshot(): void {
+    this.pagination.calculatePageSize.next({
+      totalData: this.totalItems,
+      pageSize: this.pageSize,
+      tableData: this.tableData,
+      serialNumberArray: [],
+    });
+  }
+
+  private persistListState(filters: BankListFilterState): void {
+    this.banksState.setListState({
+      items: this.tableData,
+      totalItems: this.totalItems,
+      page: this.currentPage,
+      pageSize: this.pageSize,
+      orderBy: this.orderBy,
+      ascending: this.ascending,
+      filters,
+      lastRequestSignature: this.lastRequestSignature,
+      lastPagerKey: this.lastPagerKey,
     });
   }
 }

--- a/src/app/feature-module/administration/banks/services/banks.api.service.ts
+++ b/src/app/feature-module/administration/banks/services/banks.api.service.ts
@@ -1,32 +1,17 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { environment } from '../../../../config/environment';
-import { BankViewModel, BankDetailsViewModel } from '../../../../shared/models/banks';
+import {
+  BankViewModel,
+  BankDetailsViewModel,
+  ListBanksParams,
+  CreateBankPayload,
+  UpdateBankPayload,
+} from '../../../../shared/models/banks';
 import { PagedResult, RawPagedResult, mapRawPaged } from '../../../../shared/models/pagination';
-
-export interface ListBanksParams {
-  page?: number;
-  pageSize?: number;
-  name?: string;
-  bankCode?: string;
-  isActive?: boolean;
-  orderBy?: string;
-  ascending?: boolean;
-}
-
-export interface CreateBankDto {
-  name: string;
-  bankCode: string;
-  isActive: boolean;
-}
-
-export interface UpdateBankDto {
-  name: string;
-  bankCode: string;
-  isActive: boolean;
-}
+import { buildHttpParams } from '../../../../shared/utils/http-params';
 
 @Injectable({ providedIn: 'root' })
 export class BanksApiService {
@@ -35,17 +20,26 @@ export class BanksApiService {
   constructor(private http: HttpClient) {}
 
   list(params: ListBanksParams = {}): Observable<PagedResult<BankViewModel>> {
-    const httpParams = new HttpParams({
-      fromObject: {
-        page: params.page?.toString() ?? '1',
-        page_size: params.pageSize?.toString() ?? '10',
-        ...(params.name ? { name: params.name } : {} as any),
-        ...(params.bankCode ? { bank_code: params.bankCode } : {} as any),
-        ...(params.isActive !== undefined ? { is_active: String(params.isActive) } : {} as any),
-        ...(params.orderBy ? { order_by: params.orderBy } : {} as any),
-        ...(params.ascending !== undefined ? { ascending: String(params.ascending) } : {} as any),
-      },
+    const {
+      page = 1,
+      pageSize = 10,
+      orderBy,
+      ascending,
+      name,
+      bankCode,
+      isActive,
+    } = params;
+
+    const httpParams = buildHttpParams({
+      page,
+      pageSize,
+      orderBy,
+      ascending,
+      name,
+      bankCode,
+      isActive,
     });
+
     return this.http
       .get<RawPagedResult<BankViewModel>>(this.baseUrl, { params: httpParams })
       .pipe(map(res => mapRawPaged<BankViewModel>(res)));
@@ -55,22 +49,11 @@ export class BanksApiService {
     return this.http.get<BankDetailsViewModel>(`${this.baseUrl}/${id}`);
   }
 
-  create(dto: CreateBankDto): Observable<void> {
-    const payload: any = {
-      name: dto.name,
-      bankCode: dto.bankCode,
-      is_active: dto.isActive,
-    };
-    return this.http.post<void>(this.baseUrl, payload);
+  create(dto: CreateBankPayload): Observable<void> {
+    return this.http.post<void>(this.baseUrl, dto);
   }
 
-  update(id: string, dto: UpdateBankDto): Observable<BankDetailsViewModel> {
-    const payload: any = {
-      name: dto.name,
-      bankCode: dto.bankCode,
-      is_active: dto.isActive,
-    };
-    return this.http.put<BankDetailsViewModel>(`${this.baseUrl}/${id}`, payload);
+  update(id: string, dto: UpdateBankPayload): Observable<BankDetailsViewModel> {
+    return this.http.put<BankDetailsViewModel>(`${this.baseUrl}/${id}`, dto);
   }
 }
-

--- a/src/app/shared/models/api/base-view.model.ts
+++ b/src/app/shared/models/api/base-view.model.ts
@@ -1,0 +1,21 @@
+export interface EntityIdentifier {
+  id: string;
+}
+
+export interface AuditMetadata {
+  createdAt: string;
+  createdBy?: string;
+  updatedAt?: string | null;
+  updatedBy?: string | null;
+}
+
+export interface AuditableViewModel extends EntityIdentifier, AuditMetadata {}
+
+export type SortableKeys<T> = Extract<keyof T, string>;
+
+export interface ListRequestParams<TOrderBy extends string = string> {
+  page?: number;
+  pageSize?: number;
+  orderBy?: TOrderBy;
+  ascending?: boolean;
+}

--- a/src/app/shared/models/api/list-state.ts
+++ b/src/app/shared/models/api/list-state.ts
@@ -1,0 +1,27 @@
+export interface ListViewState<
+  TItem extends Record<string, unknown>,
+  TSortField extends string,
+  TFilterState extends Record<string, unknown>
+> {
+  items: TItem[];
+  totalItems: number;
+  page: number;
+  pageSize: number;
+  orderBy: TSortField;
+  ascending: boolean;
+  filters: TFilterState;
+  lastRequestSignature?: string;
+  lastPagerKey?: string;
+}
+
+export function cloneListViewState<
+  TItem extends Record<string, unknown>,
+  TSortField extends string,
+  TFilterState extends Record<string, unknown>
+>(state: ListViewState<TItem, TSortField, TFilterState>): ListViewState<TItem, TSortField, TFilterState> {
+  return {
+    ...state,
+    items: state.items.map((item) => ({ ...item })),
+    filters: { ...state.filters },
+  };
+}

--- a/src/app/shared/models/banks.ts
+++ b/src/app/shared/models/banks.ts
@@ -1,13 +1,62 @@
-export interface BankViewModel {
-  id: string;
+import { AuditableViewModel, ListRequestParams } from './api/base-view.model';
+
+export interface BankViewModel extends AuditableViewModel {
   name: string;
   bankCode: string;
   isActive: boolean;
-  createdAt: string;
-  createdBy?: string;
-  updatedAt?: string | null;
-  updatedBy?: string | null;
 }
 
 export interface BankDetailsViewModel extends BankViewModel {}
 
+export type BankSortableField = 'createdAt' | 'name' | 'bankCode' | 'isActive';
+
+export interface BankListFilters {
+  name?: string;
+  bankCode?: string;
+  isActive?: boolean;
+}
+
+export type ListBanksParams = ListRequestParams<BankSortableField> & BankListFilters;
+
+export type BankListFilterState = {
+  name: string;
+  bankCode: string;
+  isActive: '' | 'true' | 'false';
+};
+
+export const defaultBankListFilterState: BankListFilterState = {
+  name: '',
+  bankCode: '',
+  isActive: '',
+};
+
+export function normalizeBankListFilters(
+  filters: BankListFilterState
+): BankListFilters {
+  const normalized: BankListFilters = {};
+
+  const trimmedName = filters.name?.trim();
+  if (trimmedName) {
+    normalized.name = trimmedName;
+  }
+
+  const trimmedBankCode = filters.bankCode?.trim();
+  if (trimmedBankCode) {
+    normalized.bankCode = trimmedBankCode;
+  }
+
+  if (filters.isActive !== '') {
+    normalized.isActive = filters.isActive === 'true';
+  }
+
+  return normalized;
+}
+
+export interface SaveBankPayload {
+  name: string;
+  bankCode: string;
+  isActive: boolean;
+}
+
+export type CreateBankPayload = SaveBankPayload;
+export type UpdateBankPayload = SaveBankPayload;

--- a/src/app/shared/models/users.ts
+++ b/src/app/shared/models/users.ts
@@ -1,20 +1,18 @@
+import { AuditableViewModel } from './api/base-view.model';
+
 export interface RoleViewModel {
   id: string;
   name: string;
   description: string;
 }
 
-export interface UserViewModel {
+export interface UserViewModel extends AuditableViewModel {
   // opcionalmente presente na listagem
   permissions?: RoleViewModel[];
-  id: string;
   name: string;
   email: string;
   isActive: boolean;
-  createdAt: string;
   createdBy: string;
-  updatedAt?: string | null;
-  updatedBy?: string | null;
 }
 
 export interface UserDetailsViewModel extends UserViewModel {

--- a/src/app/shared/utils/http-params.ts
+++ b/src/app/shared/utils/http-params.ts
@@ -1,0 +1,30 @@
+import { HttpParams } from '@angular/common/http';
+
+type Primitive = string | number | boolean | null | undefined;
+type ParamValue = Primitive | Primitive[];
+
+export type QueryParams = Record<string, ParamValue>;
+
+export function buildHttpParams(params: QueryParams): HttpParams {
+  let httpParams = new HttpParams();
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value === undefined || value === null || value === '') {
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      value.forEach((item) => {
+        if (item === undefined || item === null || item === '') {
+          return;
+        }
+        httpParams = httpParams.append(key, String(item));
+      });
+      return;
+    }
+
+    httpParams = httpParams.append(key, String(value));
+  });
+
+  return httpParams;
+}


### PR DESCRIPTION
## Summary
- add a reusable shared list view state helper for cloning cached collections safely
- refactor the banks state service and list component to rely on the shared view state with normalized filters and modern Angular cleanup
- centralize bank filter defaults and normalization so requests stay aligned with the API contract

## Testing
- npm run build *(fails: ng: not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e130aeb2cc832fab65887388be0561