### PR TITLE
Align admin API clients with swagger contracts

### DIFF
--- a/src/app/core/locations/locations.api.service.ts
+++ b/src/app/core/locations/locations.api.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from "@angular/core";
-import { HttpClient, HttpParams } from "@angular/common/http";
+import { HttpClient } from "@angular/common/http";
 import { Observable, of } from "rxjs";
 import { catchError, map } from "rxjs/operators";
 import { environment } from "../../config/environment";
@@ -13,6 +13,7 @@ import {
   RawPagedResult,
   mapRawPaged,
 } from "../../shared/models/pagination";
+import { buildHttpParams } from "../../shared/utils/http-params";
 
 export interface ListStatesParams {
   page?: number;
@@ -35,13 +36,11 @@ export class LocationsApiService {
   constructor(private http: HttpClient) {}
 
   listStates(params: ListStatesParams = {}): Observable<PagedResult<StateSimpleViewModel>> {
-    const httpParams = new HttpParams({
-      fromObject: {
-        page: params.page?.toString() ?? "1",
-        page_size: params.pageSize?.toString() ?? "10",
-        ...(params.orderBy ? { order_by: params.orderBy } : {}),
-        ...(params.ascending !== undefined ? { ascending: String(params.ascending) } : {}),
-      },
+    const httpParams = buildHttpParams({
+      page: params.page ?? 1,
+      pageSize: params.pageSize ?? 10,
+      orderBy: params.orderBy,
+      ascending: params.ascending,
     });
 
     return this.http
@@ -55,13 +54,11 @@ export class LocationsApiService {
     stateUf: string,
     params: ListCitiesParams = {}
   ): Observable<PagedResult<CitySimpleViewModel>> {
-    const httpParams = new HttpParams({
-      fromObject: {
-        page: params.page?.toString() ?? "1",
-        page_size: params.pageSize?.toString() ?? "10",
-        ...(params.orderBy ? { order_by: params.orderBy } : {}),
-        ...(params.ascending !== undefined ? { ascending: String(params.ascending) } : {}),
-      },
+    const httpParams = buildHttpParams({
+      page: params.page ?? 1,
+      pageSize: params.pageSize ?? 10,
+      orderBy: params.orderBy,
+      ascending: params.ascending,
     });
 
     return this.http

--- a/src/app/feature-module/administration/laboratories/laboratories/laboratories.component.ts
+++ b/src/app/feature-module/administration/laboratories/laboratories/laboratories.component.ts
@@ -27,7 +27,7 @@ export class LaboratoriesComponent implements OnInit {
   filtroDocumento = '';
   filtroAtivo: '' | 'true' | 'false' = '';
 
-  orderBy: string = 'created_at';
+  orderBy: string = 'createdAt';
   ascending = false;
   orderLabel: 'CreatedDate' | 'TradeName' | 'LegalName' | 'Document' | 'Status' = 'CreatedDate';
 
@@ -102,15 +102,15 @@ export class LaboratoriesComponent implements OnInit {
   private mapOrderField(field: 'CreatedDate' | 'TradeName' | 'LegalName' | 'Document' | 'Status'): string {
     switch (field) {
       case 'TradeName':
-        return 'trade_name';
+        return 'tradeName';
       case 'LegalName':
-        return 'legal_name';
+        return 'legalName';
       case 'Document':
         return 'document';
       case 'Status':
-        return 'active';
+        return 'isActive';
       default:
-        return 'created_at';
+        return 'createdAt';
     }
   }
 

--- a/src/app/feature-module/administration/laboratories/services/laboratories.api.service.ts
+++ b/src/app/feature-module/administration/laboratories/services/laboratories.api.service.ts
@@ -1,21 +1,15 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { environment } from '../../../../config/environment';
-import { LaboratoryDetailsViewModel, LaboratoryViewModel } from '../../../../shared/models/laboratories';
+import {
+  LaboratoryDetailsViewModel,
+  LaboratoryViewModel,
+  ListLaboratoriesParams,
+} from '../../../../shared/models/laboratories';
 import { PagedResult, RawPagedResult, mapRawPaged } from '../../../../shared/models/pagination';
-
-export interface ListLaboratoriesParams {
-  page?: number;
-  pageSize?: number;
-  tradeName?: string;
-  legalName?: string;
-  document?: string;
-  isActive?: boolean;
-  orderBy?: string;
-  ascending?: boolean;
-}
+import { buildHttpParams } from '../../../../shared/utils/http-params';
 
 export interface CreateLaboratoryDto {
   tradeName: string;
@@ -34,17 +28,15 @@ export class LaboratoriesApiService {
   constructor(private http: HttpClient) {}
 
   list(params: ListLaboratoriesParams = {}): Observable<PagedResult<LaboratoryViewModel>> {
-    const httpParams = new HttpParams({
-      fromObject: {
-        page: params.page?.toString() ?? '1',
-        page_size: params.pageSize?.toString() ?? '10',
-        ...(params.tradeName ? { trade_name: params.tradeName } : {} as any),
-        ...(params.legalName ? { legal_name: params.legalName } : {} as any),
-        ...(params.document ? { document: params.document } : {} as any),
-        ...(params.isActive !== undefined ? { is_active: String(params.isActive) } : {} as any),
-        ...(params.orderBy ? { order_by: params.orderBy } : {} as any),
-        ...(params.ascending !== undefined ? { ascending: String(params.ascending) } : {} as any),
-      },
+    const httpParams = buildHttpParams({
+      page: params.page ?? 1,
+      pageSize: params.pageSize ?? 10,
+      tradeName: params.tradeName,
+      legalName: params.legalName,
+      document: params.document,
+      isActive: params.isActive,
+      orderBy: params.orderBy,
+      ascending: params.ascending,
     });
 
     return this.http
@@ -57,23 +49,23 @@ export class LaboratoriesApiService {
   }
 
   create(dto: CreateLaboratoryDto): Observable<void> {
-    const payload: any = {
-      trade_name: dto.tradeName,
-      legal_name: dto.legalName,
+    const payload: CreateLaboratoryDto = {
+      tradeName: dto.tradeName,
+      legalName: dto.legalName,
       document: dto.document,
       observation: dto.observation ?? null,
-      is_active: dto.isActive,
+      isActive: dto.isActive,
     };
     return this.http.post<void>(this.baseUrl, payload);
   }
 
   update(id: string, dto: UpdateLaboratoryDto): Observable<LaboratoryDetailsViewModel> {
-    const payload: any = {
-      trade_name: dto.tradeName,
-      legal_name: dto.legalName,
+    const payload: UpdateLaboratoryDto = {
+      tradeName: dto.tradeName,
+      legalName: dto.legalName,
       document: dto.document,
       observation: dto.observation ?? null,
-      is_active: dto.isActive,
+      isActive: dto.isActive,
     };
     return this.http.put<LaboratoryDetailsViewModel>(`${this.baseUrl}/${id}`, payload);
   }

--- a/src/app/feature-module/administration/pharmaceutical-forms/pharmaceutical-forms/pharmaceutical-forms.component.ts
+++ b/src/app/feature-module/administration/pharmaceutical-forms/pharmaceutical-forms/pharmaceutical-forms.component.ts
@@ -24,7 +24,7 @@ export class PharmaceuticalFormsComponent implements OnInit {
   filtroNome = '';
   filtroAtivo: '' | 'true' | 'false' = '';
 
-  orderBy = 'created_at';
+  orderBy = 'createdAt';
   ascending = false;
   orderLabel: 'CreatedDate' | 'Name' | 'Status' = 'CreatedDate';
 
@@ -99,10 +99,10 @@ export class PharmaceuticalFormsComponent implements OnInit {
       case 'Name':
         return 'name';
       case 'Status':
-        return 'active';
+        return 'isActive';
       case 'CreatedDate':
       default:
-        return 'created_at';
+        return 'createdAt';
     }
   }
 

--- a/src/app/feature-module/administration/pharmaceutical-forms/services/pharmaceutical-forms.api.service.ts
+++ b/src/app/feature-module/administration/pharmaceutical-forms/services/pharmaceutical-forms.api.service.ts
@@ -1,19 +1,14 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { environment } from '../../../../config/environment';
-import { PharmaceuticalFormViewModel } from '../../../../shared/models/pharmaceutical-forms';
+import {
+  ListPharmaceuticalFormsParams,
+  PharmaceuticalFormViewModel,
+} from '../../../../shared/models/pharmaceutical-forms';
 import { PagedResult, RawPagedResult, mapRawPaged } from '../../../../shared/models/pagination';
-
-export interface ListPharmaceuticalFormsParams {
-  page?: number;
-  pageSize?: number;
-  name?: string;
-  isActive?: boolean;
-  orderBy?: string;
-  ascending?: boolean;
-}
+import { buildHttpParams } from '../../../../shared/utils/http-params';
 
 export interface CreatePharmaceuticalFormDto {
   name: string;
@@ -32,15 +27,13 @@ export class PharmaceuticalFormsApiService {
   constructor(private http: HttpClient) {}
 
   list(params: ListPharmaceuticalFormsParams = {}): Observable<PagedResult<PharmaceuticalFormViewModel>> {
-    const httpParams = new HttpParams({
-      fromObject: {
-        page: params.page?.toString() ?? '1',
-        page_size: params.pageSize?.toString() ?? '10',
-        ...(params.name ? { name: params.name } : {}),
-        ...(params.isActive !== undefined ? { is_active: String(params.isActive) } : {}),
-        ...(params.orderBy ? { order_by: params.orderBy } : {}),
-        ...(params.ascending !== undefined ? { ascending: String(params.ascending) } : {}),
-      },
+    const httpParams = buildHttpParams({
+      page: params.page ?? 1,
+      pageSize: params.pageSize ?? 10,
+      name: params.name,
+      isActive: params.isActive,
+      orderBy: params.orderBy,
+      ascending: params.ascending,
     });
 
     return this.http
@@ -53,17 +46,17 @@ export class PharmaceuticalFormsApiService {
   }
 
   create(dto: CreatePharmaceuticalFormDto): Observable<PharmaceuticalFormViewModel> {
-    const payload = {
+    const payload: CreatePharmaceuticalFormDto = {
       name: dto.name,
-      is_active: dto.isActive,
+      isActive: dto.isActive,
     };
     return this.http.post<PharmaceuticalFormViewModel>(this.baseUrl, payload);
   }
 
   update(id: string, dto: UpdatePharmaceuticalFormDto): Observable<PharmaceuticalFormViewModel> {
-    const payload = {
+    const payload: UpdatePharmaceuticalFormDto = {
       name: dto.name,
-      is_active: dto.isActive,
+      isActive: dto.isActive,
     };
     return this.http.put<PharmaceuticalFormViewModel>(`${this.baseUrl}/${id}`, payload);
   }

--- a/src/app/feature-module/administration/product-groups/product-groups/product-groups.component.ts
+++ b/src/app/feature-module/administration/product-groups/product-groups/product-groups.component.ts
@@ -19,7 +19,7 @@ export class ProductGroupsComponent implements OnInit {
   filtroNome = '';
   filtroAtivo: '' | 'true' | 'false' = '';
 
-  orderBy = 'created_at';
+  orderBy = 'createdAt';
   ascending = false;
   orderLabel: 'CreatedDate' | 'Name' | 'Status' = 'CreatedDate';
 
@@ -89,10 +89,10 @@ export class ProductGroupsComponent implements OnInit {
       case 'Name':
         return 'name';
       case 'Status':
-        return 'active';
+        return 'isActive';
       case 'CreatedDate':
       default:
-        return 'created_at';
+        return 'createdAt';
     }
   }
 

--- a/src/app/feature-module/administration/product-groups/services/product-groups.api.service.ts
+++ b/src/app/feature-module/administration/product-groups/services/product-groups.api.service.ts
@@ -1,19 +1,14 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { environment } from '../../../../config/environment';
-import { ProductGroupViewModel } from '../../../../shared/models/product-groups';
+import {
+  ListProductGroupsParams,
+  ProductGroupViewModel,
+} from '../../../../shared/models/product-groups';
 import { PagedResult, RawPagedResult, mapRawPaged } from '../../../../shared/models/pagination';
-
-export interface ListProductGroupsParams {
-  page?: number;
-  pageSize?: number;
-  name?: string;
-  isActive?: boolean;
-  orderBy?: string;
-  ascending?: boolean;
-}
+import { buildHttpParams } from '../../../../shared/utils/http-params';
 
 export interface CreateProductGroupDto {
   name: string;
@@ -32,15 +27,13 @@ export class ProductGroupsApiService {
   constructor(private http: HttpClient) {}
 
   list(params: ListProductGroupsParams = {}): Observable<PagedResult<ProductGroupViewModel>> {
-    const httpParams = new HttpParams({
-      fromObject: {
-        page: params.page?.toString() ?? '1',
-        page_size: params.pageSize?.toString() ?? '10',
-        ...(params.name ? { name: params.name } : {}),
-        ...(params.isActive !== undefined ? { is_active: String(params.isActive) } : {}),
-        ...(params.orderBy ? { order_by: params.orderBy } : {}),
-        ...(params.ascending !== undefined ? { ascending: String(params.ascending) } : {}),
-      },
+    const httpParams = buildHttpParams({
+      page: params.page ?? 1,
+      pageSize: params.pageSize ?? 10,
+      name: params.name,
+      isActive: params.isActive,
+      orderBy: params.orderBy,
+      ascending: params.ascending,
     });
 
     return this.http
@@ -53,17 +46,17 @@ export class ProductGroupsApiService {
   }
 
   create(dto: CreateProductGroupDto): Observable<ProductGroupViewModel> {
-    const payload = {
+    const payload: CreateProductGroupDto = {
       name: dto.name,
-      is_active: dto.isActive,
+      isActive: dto.isActive,
     };
     return this.http.post<ProductGroupViewModel>(this.baseUrl, payload);
   }
 
   update(id: string, dto: UpdateProductGroupDto): Observable<ProductGroupViewModel> {
-    const payload = {
+    const payload: UpdateProductGroupDto = {
       name: dto.name,
-      is_active: dto.isActive,
+      isActive: dto.isActive,
     };
     return this.http.put<ProductGroupViewModel>(`${this.baseUrl}/${id}`, payload);
   }

--- a/src/app/feature-module/administration/projects/project-upsert/project-upsert.component.ts
+++ b/src/app/feature-module/administration/projects/project-upsert/project-upsert.component.ts
@@ -218,7 +218,7 @@ export class ProjectUpsertComponent implements OnInit {
 
   private loadLaboratories() {
     this.labsApi
-      .list({ page: 1, pageSize: 100, orderBy: 'trade_name', ascending: true })
+      .list({ page: 1, pageSize: 100, orderBy: 'tradeName', ascending: true })
       .subscribe((res) => {
         this.labs = res.items || [];
         if (!this.id() && !this.isReadOnly() && this.labs.length === 1) {

--- a/src/app/feature-module/administration/projects/projects/projects.component.ts
+++ b/src/app/feature-module/administration/projects/projects/projects.component.ts
@@ -26,7 +26,7 @@ export class ProjectsComponent implements OnInit {
   filtroLaboratorio = '';
   filtroAtivo: '' | 'true' | 'false' = '';
 
-  orderBy = 'created_at';
+  orderBy = 'createdAt';
   ascending = false;
   orderLabel: 'CreatedDate' | 'Name' | 'Status' = 'CreatedDate';
 
@@ -117,10 +117,10 @@ export class ProjectsComponent implements OnInit {
       case 'Name':
         return 'name';
       case 'Status':
-        return 'active';
+        return 'isActive';
       case 'CreatedDate':
       default:
-        return 'created_at';
+        return 'createdAt';
     }
   }
 
@@ -153,7 +153,7 @@ export class ProjectsComponent implements OnInit {
 
   private loadLaboratories() {
     this.labsApi
-      .list({ page: 1, pageSize: 100, orderBy: 'trade_name', ascending: true })
+      .list({ page: 1, pageSize: 100, orderBy: 'tradeName', ascending: true })
       .subscribe((res) => {
         this.labs = res.items || [];
       });

--- a/src/app/feature-module/administration/projects/services/projects.api.service.ts
+++ b/src/app/feature-module/administration/projects/services/projects.api.service.ts
@@ -1,27 +1,20 @@
 import { Injectable } from "@angular/core";
-import { HttpClient, HttpParams } from "@angular/common/http";
+import { HttpClient } from "@angular/common/http";
 import { Observable } from "rxjs";
 import { map } from "rxjs/operators";
 import { environment } from "../../../../config/environment";
 import {
+  ListProjectsParams,
   ProjectInput,
   ProjectViewModel,
 } from "../../../../shared/models/projects";
+export type { ListProjectsParams } from "../../../../shared/models/projects";
 import {
   PagedResult,
   RawPagedResult,
   mapRawPaged,
 } from "../../../../shared/models/pagination";
-
-export interface ListProjectsParams {
-  page?: number;
-  pageSize?: number;
-  laboratoryId?: string;
-  name?: string;
-  isActive?: boolean;
-  orderBy?: string;
-  ascending?: boolean;
-}
+import { buildHttpParams } from "../../../../shared/utils/http-params";
 
 @Injectable({ providedIn: "root" })
 export class ProjectsApiService {
@@ -30,16 +23,14 @@ export class ProjectsApiService {
   constructor(private http: HttpClient) {}
 
   list(params: ListProjectsParams = {}): Observable<PagedResult<ProjectViewModel>> {
-    const httpParams = new HttpParams({
-      fromObject: {
-        page: params.page?.toString() ?? "1",
-        page_size: params.pageSize?.toString() ?? "10",
-        ...(params.laboratoryId ? { laboratory_id: params.laboratoryId } : {}),
-        ...(params.name ? { name: params.name } : {}),
-        ...(params.isActive !== undefined ? { is_active: String(params.isActive) } : {}),
-        ...(params.orderBy ? { order_by: params.orderBy } : {}),
-        ...(params.ascending !== undefined ? { ascending: String(params.ascending) } : {}),
-      },
+    const httpParams = buildHttpParams({
+      page: params.page ?? 1,
+      pageSize: params.pageSize ?? 10,
+      laboratoryId: params.laboratoryId,
+      name: params.name,
+      isActive: params.isActive,
+      orderBy: params.orderBy,
+      ascending: params.ascending,
     });
 
     return this.http
@@ -62,23 +53,23 @@ export class ProjectsApiService {
   private toPayload(input: ProjectInput): any {
     return {
       name: input.name,
-      laboratory_id: input.laboratoryId,
+      laboratoryId: input.laboratoryId,
       observation: input.observation ?? null,
-      emit_return_invoice: input.emitReturnInvoice,
-      emit_invoice: input.emitInvoice,
+      emitReturnInvoice: input.emitReturnInvoice,
+      emitInvoice: input.emitInvoice,
       stock: input.stock
         ? {
-            main_stock: input.stock.mainStock,
-            kit_stock: input.stock.kitStock,
-            sample_stock: input.stock.sampleStock,
-            blocked_stock: input.stock.blockedStock,
-            block_similar_lot: input.stock.blockSimilarLot,
-            block_before_expiration_in_months:
+            mainStock: input.stock.mainStock,
+            kitStock: input.stock.kitStock,
+            sampleStock: input.stock.sampleStock,
+            blockedStock: input.stock.blockedStock,
+            blockSimilarLot: input.stock.blockSimilarLot,
+            blockBeforeExpirationInMonths:
               input.stock.blockBeforeExpirationInMonths,
           }
         : null,
-      allowed_service_types: input.allowedServiceTypes,
-      is_active: input.isActive,
+      allowedServiceTypes: input.allowedServiceTypes,
+      isActive: input.isActive,
     };
   }
 }

--- a/src/app/feature-module/administration/return-units/return-unit-upsert/return-unit-upsert.component.ts
+++ b/src/app/feature-module/administration/return-units/return-unit-upsert/return-unit-upsert.component.ts
@@ -259,7 +259,7 @@ export class ReturnUnitUpsertComponent implements OnInit {
 
   private loadLabs() {
     this.labsApi
-      .list({ page: 1, pageSize: 100, orderBy: 'trade_name', ascending: true })
+      .list({ page: 1, pageSize: 100, orderBy: 'tradeName', ascending: true })
       .subscribe((res) => {
         this.labs = res.items || [];
       });

--- a/src/app/feature-module/administration/return-units/return-units/return-units.component.ts
+++ b/src/app/feature-module/administration/return-units/return-units/return-units.component.ts
@@ -29,7 +29,7 @@ export class ReturnUnitsComponent implements OnInit {
   filtroLaboratorio = '';
   filtroAtivo: '' | 'true' | 'false' = '';
 
-  orderBy = 'created_at';
+  orderBy = 'createdAt';
   ascending = false;
   orderLabel: 'CreatedDate' | 'Name' | 'Status' = 'CreatedDate';
 
@@ -120,10 +120,10 @@ export class ReturnUnitsComponent implements OnInit {
       case 'Name':
         return 'name';
       case 'Status':
-        return 'active';
+        return 'isActive';
       case 'CreatedDate':
       default:
-        return 'created_at';
+        return 'createdAt';
     }
   }
 
@@ -156,7 +156,7 @@ export class ReturnUnitsComponent implements OnInit {
 
   private loadLaboratories() {
     this.labsApi
-      .list({ page: 1, pageSize: 100, orderBy: 'trade_name', ascending: true })
+      .list({ page: 1, pageSize: 100, orderBy: 'tradeName', ascending: true })
       .subscribe((res) => {
         this.labs = res.items || [];
       });

--- a/src/app/feature-module/administration/return-units/services/return-units.api.service.ts
+++ b/src/app/feature-module/administration/return-units/services/return-units.api.service.ts
@@ -1,27 +1,20 @@
 import { Injectable } from "@angular/core";
-import { HttpClient, HttpParams } from "@angular/common/http";
+import { HttpClient } from "@angular/common/http";
 import { Observable } from "rxjs";
 import { map } from "rxjs/operators";
 import { environment } from "../../../../config/environment";
 import {
+  ListReturnUnitsParams,
   ReturnUnitInput,
   ReturnUnitViewModel,
 } from "../../../../shared/models/return-units";
+export type { ListReturnUnitsParams } from "../../../../shared/models/return-units";
 import {
   PagedResult,
   RawPagedResult,
   mapRawPaged,
 } from "../../../../shared/models/pagination";
-
-export interface ListReturnUnitsParams {
-  page?: number;
-  pageSize?: number;
-  laboratoryId?: string;
-  name?: string;
-  isActive?: boolean;
-  orderBy?: string;
-  ascending?: boolean;
-}
+import { buildHttpParams } from "../../../../shared/utils/http-params";
 
 @Injectable({ providedIn: "root" })
 export class ReturnUnitsApiService {
@@ -30,16 +23,14 @@ export class ReturnUnitsApiService {
   constructor(private http: HttpClient) {}
 
   list(params: ListReturnUnitsParams = {}): Observable<PagedResult<ReturnUnitViewModel>> {
-    const httpParams = new HttpParams({
-      fromObject: {
-        page: params.page?.toString() ?? "1",
-        page_size: params.pageSize?.toString() ?? "10",
-        ...(params.laboratoryId ? { laboratory_id: params.laboratoryId } : {}),
-        ...(params.name ? { name: params.name } : {}),
-        ...(params.isActive !== undefined ? { is_active: String(params.isActive) } : {}),
-        ...(params.orderBy ? { order_by: params.orderBy } : {}),
-        ...(params.ascending !== undefined ? { ascending: String(params.ascending) } : {}),
-      },
+    const httpParams = buildHttpParams({
+      page: params.page ?? 1,
+      pageSize: params.pageSize ?? 10,
+      laboratoryId: params.laboratoryId,
+      name: params.name,
+      isActive: params.isActive,
+      orderBy: params.orderBy,
+      ascending: params.ascending,
     });
 
     return this.http
@@ -61,25 +52,25 @@ export class ReturnUnitsApiService {
 
   private toPayload(input: ReturnUnitInput): any {
     return {
-      laboratory_id: input.laboratoryId,
+      laboratoryId: input.laboratoryId,
       name: input.name,
-      legal_name: input.legalName,
-      trade_name: input.tradeName,
+      legalName: input.legalName,
+      tradeName: input.tradeName,
       document: input.document,
-      state_registration: input.stateRegistration ?? null,
+      stateRegistration: input.stateRegistration ?? null,
       address: {
-        zip_code: input.address.zipCode,
+        zipCode: input.address.zipCode,
         street: input.address.street,
         number: input.address.number,
-        additional_details: input.address.additionalDetails ?? null,
-        reference_point: input.address.referencePoint ?? null,
+        additionalDetails: input.address.additionalDetails ?? null,
+        referencePoint: input.address.referencePoint ?? null,
         neighborhood: input.address.neighborhood,
-        city_id: input.address.cityId,
+        cityId: input.address.cityId,
       },
       phone: input.phone ?? null,
       email: input.email ?? null,
       observation: input.observation ?? null,
-      is_active: input.isActive,
+      isActive: input.isActive,
     };
   }
 }

--- a/src/app/feature-module/administration/supplies/services/supplies.api.service.ts
+++ b/src/app/feature-module/administration/supplies/services/supplies.api.service.ts
@@ -1,29 +1,23 @@
 import { Injectable } from "@angular/core";
-import { HttpClient, HttpParams } from "@angular/common/http";
+import { HttpClient } from "@angular/common/http";
 import { Observable } from "rxjs";
 import { map } from "rxjs/operators";
 import { environment } from "../../../../config/environment";
 import {
+  ListSuppliesParams,
   DryPackageInput,
   PackageViewModel,
   RefrigeratedPackageInput,
   SimpleItemInput,
   SimpleItemViewModel,
 } from "../../../../shared/models/supplies";
+export type { ListSuppliesParams } from "../../../../shared/models/supplies";
 import {
   PagedResult,
   RawPagedResult,
   mapRawPaged,
 } from "../../../../shared/models/pagination";
-
-export interface ListSuppliesParams {
-  page?: number;
-  pageSize?: number;
-  name?: string;
-  isActive?: boolean;
-  orderBy?: string;
-  ascending?: boolean;
-}
+import { buildHttpParams } from "../../../../shared/utils/http-params";
 
 @Injectable({ providedIn: "root" })
 export class SuppliesApiService {
@@ -32,15 +26,13 @@ export class SuppliesApiService {
   constructor(private http: HttpClient) {}
 
   list(params: ListSuppliesParams = {}): Observable<PagedResult<SimpleItemViewModel>> {
-    const httpParams = new HttpParams({
-      fromObject: {
-        page: params.page?.toString() ?? "1",
-        page_size: params.pageSize?.toString() ?? "10",
-        ...(params.name ? { name: params.name } : {}),
-        ...(params.isActive !== undefined ? { is_active: String(params.isActive) } : {}),
-        ...(params.orderBy ? { order_by: params.orderBy } : {}),
-        ...(params.ascending !== undefined ? { ascending: String(params.ascending) } : {}),
-      },
+    const httpParams = buildHttpParams({
+      page: params.page ?? 1,
+      pageSize: params.pageSize ?? 10,
+      name: params.name,
+      isActive: params.isActive,
+      orderBy: params.orderBy,
+      ascending: params.ascending,
     });
 
     return this.http
@@ -105,7 +97,7 @@ export class SuppliesApiService {
     return {
       name: input.name,
       price: input.price,
-      is_active: input.isActive,
+      isActive: input.isActive,
       type: input.type,
     };
   }
@@ -118,14 +110,14 @@ export class SuppliesApiService {
       width: input.width,
       depth: input.depth,
       barcode: input.barcode,
-      is_active: input.isActive,
+      isActive: input.isActive,
     };
   }
 
   private toRefrigeratedPackagePayload(input: RefrigeratedPackageInput): any {
     return {
       ...this.toDryPackagePayload(input),
-      cooling_duration_hours: input.coolingDurationHours,
+      coolingDurationHours: input.coolingDurationHours,
     };
   }
 }

--- a/src/app/feature-module/administration/supplies/supplies/supplies.component.ts
+++ b/src/app/feature-module/administration/supplies/supplies/supplies.component.ts
@@ -60,7 +60,7 @@ export class SuppliesComponent implements OnInit {
   filtroNome = '';
   filtroAtivo: '' | 'true' | 'false' = '';
 
-  orderBy = 'created_at';
+  orderBy = 'createdAt';
   ascending = false;
   orderLabel: 'CreatedDate' | 'Name' | 'Status' = 'CreatedDate';
 
@@ -145,10 +145,10 @@ export class SuppliesComponent implements OnInit {
       case 'Name':
         return 'name';
       case 'Status':
-        return 'is_active';
+        return 'isActive';
       case 'CreatedDate':
       default:
-        return 'created_at';
+        return 'createdAt';
     }
   }
 

--- a/src/app/feature-module/administration/units/services/units.api.service.ts
+++ b/src/app/feature-module/administration/units/services/units.api.service.ts
@@ -1,19 +1,11 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { environment } from '../../../../config/environment';
-import { UnitViewModel } from '../../../../shared/models/units';
+import { ListUnitsParams, UnitViewModel } from '../../../../shared/models/units';
 import { PagedResult, RawPagedResult, mapRawPaged } from '../../../../shared/models/pagination';
-
-export interface ListUnitsParams {
-  page?: number;
-  pageSize?: number;
-  name?: string;
-  isActive?: boolean;
-  orderBy?: string;
-  ascending?: boolean;
-}
+import { buildHttpParams } from '../../../../shared/utils/http-params';
 
 export interface CreateUnitDto {
   name: string;
@@ -32,15 +24,13 @@ export class UnitsApiService {
   constructor(private http: HttpClient) {}
 
   list(params: ListUnitsParams = {}): Observable<PagedResult<UnitViewModel>> {
-    const httpParams = new HttpParams({
-      fromObject: {
-        page: params.page?.toString() ?? '1',
-        page_size: params.pageSize?.toString() ?? '10',
-        ...(params.name ? { name: params.name } : {}),
-        ...(params.isActive !== undefined ? { is_active: String(params.isActive) } : {}),
-        ...(params.orderBy ? { order_by: params.orderBy } : {}),
-        ...(params.ascending !== undefined ? { ascending: String(params.ascending) } : {}),
-      },
+    const httpParams = buildHttpParams({
+      page: params.page ?? 1,
+      pageSize: params.pageSize ?? 10,
+      name: params.name,
+      isActive: params.isActive,
+      orderBy: params.orderBy,
+      ascending: params.ascending,
     });
 
     return this.http
@@ -53,17 +43,17 @@ export class UnitsApiService {
   }
 
   create(dto: CreateUnitDto): Observable<UnitViewModel> {
-    const payload = {
+    const payload: CreateUnitDto = {
       name: dto.name,
-      is_active: dto.isActive,
+      isActive: dto.isActive,
     };
     return this.http.post<UnitViewModel>(this.baseUrl, payload);
   }
 
   update(id: string, dto: UpdateUnitDto): Observable<UnitViewModel> {
-    const payload = {
+    const payload: UpdateUnitDto = {
       name: dto.name,
-      is_active: dto.isActive,
+      isActive: dto.isActive,
     };
     return this.http.put<UnitViewModel>(`${this.baseUrl}/${id}`, payload);
   }

--- a/src/app/feature-module/administration/units/units/units.component.ts
+++ b/src/app/feature-module/administration/units/units/units.component.ts
@@ -24,7 +24,7 @@ export class UnitsComponent implements OnInit {
   filtroNome = '';
   filtroAtivo: '' | 'true' | 'false' = '';
 
-  orderBy = 'created_at';
+  orderBy = 'createdAt';
   ascending = false;
   orderLabel: 'CreatedDate' | 'Name' | 'Status' = 'CreatedDate';
 
@@ -94,10 +94,10 @@ export class UnitsComponent implements OnInit {
       case 'Name':
         return 'name';
       case 'Status':
-        return 'active';
+        return 'isActive';
       case 'CreatedDate':
       default:
-        return 'created_at';
+        return 'createdAt';
     }
   }
 

--- a/src/app/feature-module/administration/user-management/services/roles.api.service.ts
+++ b/src/app/feature-module/administration/user-management/services/roles.api.service.ts
@@ -1,10 +1,11 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { environment } from '../../../../config/environment';
 import { RoleViewModel } from '../../../../shared/models/users';
 import { PagedResult, RawPagedResult, mapRawPaged } from '../../../../shared/models/pagination';
+import { buildHttpParams } from '../../../../shared/utils/http-params';
 
 export interface ListRolesParams {
   page?: number;
@@ -18,12 +19,12 @@ export class RolesApiService {
   private readonly baseUrl = `${environment.apiBaseUrl}/api/v1/roles`;
   constructor(private http: HttpClient) {}
   list(params: ListRolesParams = {}): Observable<PagedResult<RoleViewModel>> {
-    const httpParams = new HttpParams({ fromObject: {
-      page: params.page?.toString() ?? '1',
-      page_size: params.pageSize?.toString() ?? '10',
-      ...(params.orderBy ? { order_by: params.orderBy } : {}),
-      ...(params.ascending !== undefined ? { ascending: String(params.ascending) } : {}),
-    }});
+    const httpParams = buildHttpParams({
+      page: params.page ?? 1,
+      pageSize: params.pageSize ?? 10,
+      orderBy: params.orderBy,
+      ascending: params.ascending,
+    });
     return this.http
       .get<RawPagedResult<RoleViewModel>>(this.baseUrl, { params: httpParams })
       .pipe(map(res => mapRawPaged<RoleViewModel>(res)));

--- a/src/app/feature-module/administration/user-management/services/users.api.service.ts
+++ b/src/app/feature-module/administration/user-management/services/users.api.service.ts
@@ -1,20 +1,15 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { environment } from '../../../../config/environment';
-import { UserViewModel, UserDetailsViewModel } from '../../../../shared/models/users';
+import {
+  ListUsersParams,
+  UserViewModel,
+  UserDetailsViewModel,
+} from '../../../../shared/models/users';
 import { PagedResult, RawPagedResult, mapRawPaged } from '../../../../shared/models/pagination';
-
-export interface ListUsersParams {
-  page?: number;
-  pageSize?: number;
-  name?: string;
-  email?: string;
-  isActive?: boolean;
-  orderBy?: string;
-  ascending?: boolean;
-}
+import { buildHttpParams } from '../../../../shared/utils/http-params';
 
 export interface CreateUserDto {
   name: string;
@@ -36,15 +31,15 @@ export class UsersApiService {
   constructor(private http: HttpClient) {}
 
   list(params: ListUsersParams = {}): Observable<PagedResult<UserViewModel>> {
-    const httpParams = new HttpParams({ fromObject: {
-      page: params.page?.toString() ?? '1',
-      page_size: params.pageSize?.toString() ?? '10',
-      ...(params.name ? { name: params.name } : {}),
-      ...(params.email ? { email: params.email } : {}),
-      ...(params.isActive !== undefined ? { is_active: String(params.isActive) } : {}),
-      ...(params.orderBy ? { order_by: params.orderBy } : {}),
-      ...(params.ascending !== undefined ? { ascending: String(params.ascending) } : {}),
-    }});
+    const httpParams = buildHttpParams({
+      page: params.page ?? 1,
+      pageSize: params.pageSize ?? 10,
+      name: params.name,
+      email: params.email,
+      isActive: params.isActive,
+      orderBy: params.orderBy,
+      ascending: params.ascending,
+    });
     return this.http
       .get<RawPagedResult<UserViewModel>>(this.baseUrl, { params: httpParams })
       .pipe(map(res => mapRawPaged<UserViewModel>(res)));
@@ -55,20 +50,20 @@ export class UsersApiService {
   }
 
   create(dto: CreateUserDto): Observable<void> {
-    const payload: any = {
+    const payload: CreateUserDto = {
       name: dto.name,
       email: dto.email,
       permissions: dto.permissions,
-      is_active: dto.isActive,
+      isActive: dto.isActive,
     };
     return this.http.post<void>(this.baseUrl, payload);
   }
 
   update(id: string, dto: UpdateUserDto): Observable<void> {
-    const payload: any = {
+    const payload: UpdateUserDto = {
       name: dto.name,
       permissions: dto.permissions,
-      is_active: dto.isActive,
+      isActive: dto.isActive,
     };
     return this.http.put<void>(`${this.baseUrl}/${id}`, payload);
   }

--- a/src/app/feature-module/administration/user-management/users/users.component.ts
+++ b/src/app/feature-module/administration/user-management/users/users.component.ts
@@ -32,7 +32,7 @@ export class UsersComponent implements OnInit {
   // sem filtro por função na listagem
 
   // ordenação
-  orderBy: string = 'created_at';
+  orderBy: string = 'createdAt';
   ascending: boolean = false;
 
   orderLabel: string = 'CreatedDate';
@@ -74,11 +74,11 @@ export class UsersComponent implements OnInit {
 
   private mapOrderField(field: string): string {
     switch (field) {
-      case 'CreatedDate': return 'created_at';
+      case 'CreatedDate': return 'createdAt';
       case 'Name':        return 'name';
       case 'Email':       return 'email';
-      case 'Status':      return 'active';
-      default:            return 'created_at';
+      case 'Status':      return 'isActive';
+      default:            return 'createdAt';
     }
   }
 

--- a/src/app/shared/models/laboratories.ts
+++ b/src/app/shared/models/laboratories.ts
@@ -1,3 +1,5 @@
+import { ListRequestParams } from "./api/base-view.model";
+
 export interface LaboratorySimpleViewModel {
   id: string;
   legalName: string;
@@ -18,3 +20,20 @@ export interface LaboratoryViewModel {
 }
 
 export interface LaboratoryDetailsViewModel extends LaboratoryViewModel {}
+
+export type LaboratorySortableField =
+  | "createdAt"
+  | "tradeName"
+  | "legalName"
+  | "document"
+  | "isActive";
+
+export interface LaboratoryListFilters {
+  tradeName?: string;
+  legalName?: string;
+  document?: string;
+  isActive?: boolean;
+}
+
+export type ListLaboratoriesParams =
+  ListRequestParams<LaboratorySortableField> & LaboratoryListFilters;

--- a/src/app/shared/models/pharmaceutical-forms.ts
+++ b/src/app/shared/models/pharmaceutical-forms.ts
@@ -1,3 +1,5 @@
+import { ListRequestParams } from "./api/base-view.model";
+
 export interface PharmaceuticalFormViewModel {
   id: string;
   name: string;
@@ -9,3 +11,14 @@ export interface PharmaceuticalFormViewModel {
 }
 
 export interface PharmaceuticalFormDetailsViewModel extends PharmaceuticalFormViewModel {}
+
+export type PharmaceuticalFormSortableField = "createdAt" | "name" | "isActive";
+
+export interface PharmaceuticalFormListFilters {
+  name?: string;
+  isActive?: boolean;
+}
+
+export type ListPharmaceuticalFormsParams =
+  ListRequestParams<PharmaceuticalFormSortableField> &
+  PharmaceuticalFormListFilters;

--- a/src/app/shared/models/product-groups.ts
+++ b/src/app/shared/models/product-groups.ts
@@ -1,3 +1,5 @@
+import { ListRequestParams } from "./api/base-view.model";
+
 export interface ProductGroupViewModel {
   id: string;
   name: string;
@@ -9,3 +11,13 @@ export interface ProductGroupViewModel {
 }
 
 export interface ProductGroupDetailsViewModel extends ProductGroupViewModel {}
+
+export type ProductGroupSortableField = "createdAt" | "name" | "isActive";
+
+export interface ProductGroupListFilters {
+  name?: string;
+  isActive?: boolean;
+}
+
+export type ListProductGroupsParams =
+  ListRequestParams<ProductGroupSortableField> & ProductGroupListFilters;

--- a/src/app/shared/models/projects.ts
+++ b/src/app/shared/models/projects.ts
@@ -1,4 +1,5 @@
 import { LaboratorySimpleViewModel } from "./laboratories";
+import { ListRequestParams } from "./api/base-view.model";
 
 export interface ServiceTypeViewModel {
   id: number;
@@ -49,3 +50,14 @@ export interface StockConfigurationInput {
   blockSimilarLot: boolean;
   blockBeforeExpirationInMonths: number;
 }
+
+export type ProjectSortableField = "createdAt" | "name" | "isActive";
+
+export interface ProjectListFilters {
+  laboratoryId?: string;
+  name?: string;
+  isActive?: boolean;
+}
+
+export type ListProjectsParams =
+  ListRequestParams<ProjectSortableField> & ProjectListFilters;

--- a/src/app/shared/models/return-units.ts
+++ b/src/app/shared/models/return-units.ts
@@ -1,5 +1,6 @@
 import { AddressViewModel } from "./addresses";
 import { LaboratorySimpleViewModel } from "./laboratories";
+import { ListRequestParams } from "./api/base-view.model";
 
 export interface ReturnUnitViewModel {
   id: string;
@@ -41,3 +42,14 @@ export interface ReturnUnitInput {
   observation?: string | null;
   isActive: boolean;
 }
+
+export type ReturnUnitSortableField = "createdAt" | "name" | "isActive";
+
+export interface ReturnUnitListFilters {
+  laboratoryId?: string;
+  name?: string;
+  isActive?: boolean;
+}
+
+export type ListReturnUnitsParams =
+  ListRequestParams<ReturnUnitSortableField> & ReturnUnitListFilters;

--- a/src/app/shared/models/supplies.ts
+++ b/src/app/shared/models/supplies.ts
@@ -1,3 +1,5 @@
+import { ListRequestParams } from "./api/base-view.model";
+
 export type SimpleItemType = "Label" | "Receipt" | "SecurityEnvelope";
 
 export enum SupplyType {
@@ -57,3 +59,13 @@ export interface DryPackageInput {
 export interface RefrigeratedPackageInput extends DryPackageInput {
   coolingDurationHours: number;
 }
+
+export type SupplySortableField = "createdAt" | "name" | "isActive";
+
+export interface SupplyListFilters {
+  name?: string;
+  isActive?: boolean;
+}
+
+export type ListSuppliesParams =
+  ListRequestParams<SupplySortableField> & SupplyListFilters;

--- a/src/app/shared/models/units.ts
+++ b/src/app/shared/models/units.ts
@@ -1,3 +1,5 @@
+import { ListRequestParams } from "./api/base-view.model";
+
 export interface UnitViewModel {
   id: string;
   name: string;
@@ -9,3 +11,12 @@ export interface UnitViewModel {
 }
 
 export interface UnitDetailsViewModel extends UnitViewModel {}
+
+export type UnitSortableField = "createdAt" | "name" | "isActive";
+
+export interface UnitListFilters {
+  name?: string;
+  isActive?: boolean;
+}
+
+export type ListUnitsParams = ListRequestParams<UnitSortableField> & UnitListFilters;

--- a/src/app/shared/models/users.ts
+++ b/src/app/shared/models/users.ts
@@ -1,4 +1,4 @@
-import { AuditableViewModel } from './api/base-view.model';
+import { AuditableViewModel, ListRequestParams } from './api/base-view.model';
 
 export interface RoleViewModel {
   id: string;
@@ -18,3 +18,13 @@ export interface UserViewModel extends AuditableViewModel {
 export interface UserDetailsViewModel extends UserViewModel {
   permissions: RoleViewModel[];
 }
+
+export type UserSortableField = 'createdAt' | 'name' | 'email' | 'isActive';
+
+export interface UserListFilters {
+  name?: string;
+  email?: string;
+  isActive?: boolean;
+}
+
+export type ListUsersParams = ListRequestParams<UserSortableField> & UserListFilters;


### PR DESCRIPTION
## Summary
- update admin API services to send camelCase payloads and query params while re-exporting typed list request definitions from shared models
- extend shared models with strongly typed list parameter definitions for pagination, filtering, and sorting
- adjust admin listing components to request camelCase sort fields when hitting the back-end

## Testing
- npm run build *(fails: ng not found in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68e1458c83cc832f9660a1f3e4037fdd