### PR TITLE
Fix list state typings for administration modules

### DIFF
--- a/src/app/feature-module/administration/projects/projects/projects.component.ts
+++ b/src/app/feature-module/administration/projects/projects/projects.component.ts
@@ -1,7 +1,13 @@
 import { Component, OnInit } from '@angular/core';
 import { PaginationService } from '../../../../shared/custom-pagination/pagination.service';
-import { ProjectsApiService, ListProjectsParams } from '../services/projects.api.service';
-import { ProjectViewModel } from '../../../../shared/models/projects';
+import {
+  ProjectsApiService,
+  ListProjectsParams,
+} from '../services/projects.api.service';
+import {
+  ProjectSortableField,
+  ProjectViewModel,
+} from '../../../../shared/models/projects';
 import { LaboratoriesApiService } from '../../laboratories/services/laboratories.api.service';
 import { LaboratoryViewModel } from '../../../../shared/models/laboratories';
 import { ProjectsStateService } from '../services/projects-state.service';
@@ -26,7 +32,7 @@ export class ProjectsComponent implements OnInit {
   filtroLaboratorio = '';
   filtroAtivo: '' | 'true' | 'false' = '';
 
-  orderBy = 'createdAt';
+  orderBy: ProjectSortableField = 'createdAt';
   ascending = false;
   orderLabel: 'CreatedDate' | 'Name' | 'Status' = 'CreatedDate';
 
@@ -112,7 +118,7 @@ export class ProjectsComponent implements OnInit {
     this.loadPage();
   }
 
-  private mapOrderField(field: 'CreatedDate' | 'Name' | 'Status'): string {
+  private mapOrderField(field: 'CreatedDate' | 'Name' | 'Status'): ProjectSortableField {
     switch (field) {
       case 'Name':
         return 'name';

--- a/src/app/feature-module/administration/projects/services/projects-state.service.ts
+++ b/src/app/feature-module/administration/projects/services/projects-state.service.ts
@@ -1,5 +1,8 @@
 import { Injectable } from '@angular/core';
-import { ProjectViewModel } from '../../../../shared/models/projects';
+import {
+  ProjectSortableField,
+  ProjectViewModel,
+} from '../../../../shared/models/projects';
 
 function cloneProject(project: ProjectViewModel): ProjectViewModel {
   return {
@@ -18,7 +21,7 @@ interface ProjectsListState {
   filtroNome: string;
   filtroLaboratorio: string;
   filtroAtivo: '' | 'true' | 'false';
-  orderBy: string;
+  orderBy: ProjectSortableField;
   ascending: boolean;
   orderLabel: 'CreatedDate' | 'Name' | 'Status';
   lastRequestSignature?: string;

--- a/src/app/feature-module/administration/return-units/return-units/return-units.component.ts
+++ b/src/app/feature-module/administration/return-units/return-units/return-units.component.ts
@@ -4,7 +4,10 @@ import {
   ReturnUnitsApiService,
   ListReturnUnitsParams,
 } from '../services/return-units.api.service';
-import { ReturnUnitViewModel } from '../../../../shared/models/return-units';
+import {
+  ReturnUnitSortableField,
+  ReturnUnitViewModel,
+} from '../../../../shared/models/return-units';
 import { LaboratoriesApiService } from '../../laboratories/services/laboratories.api.service';
 import { LaboratoryViewModel } from '../../../../shared/models/laboratories';
 import { ReturnUnitsStateService } from '../services/return-units-state.service';
@@ -29,7 +32,7 @@ export class ReturnUnitsComponent implements OnInit {
   filtroLaboratorio = '';
   filtroAtivo: '' | 'true' | 'false' = '';
 
-  orderBy = 'createdAt';
+  orderBy: ReturnUnitSortableField = 'createdAt';
   ascending = false;
   orderLabel: 'CreatedDate' | 'Name' | 'Status' = 'CreatedDate';
 
@@ -115,7 +118,7 @@ export class ReturnUnitsComponent implements OnInit {
     this.loadPage();
   }
 
-  private mapOrderField(field: 'CreatedDate' | 'Name' | 'Status'): string {
+  private mapOrderField(field: 'CreatedDate' | 'Name' | 'Status'): ReturnUnitSortableField {
     switch (field) {
       case 'Name':
         return 'name';

--- a/src/app/feature-module/administration/return-units/services/return-units-state.service.ts
+++ b/src/app/feature-module/administration/return-units/services/return-units-state.service.ts
@@ -1,5 +1,8 @@
 import { Injectable } from '@angular/core';
-import { ReturnUnitViewModel } from '../../../../shared/models/return-units';
+import {
+  ReturnUnitSortableField,
+  ReturnUnitViewModel,
+} from '../../../../shared/models/return-units';
 
 interface ReturnUnitsListState {
   tableData: ReturnUnitViewModel[];
@@ -9,7 +12,7 @@ interface ReturnUnitsListState {
   filtroNome: string;
   filtroLaboratorio: string;
   filtroAtivo: '' | 'true' | 'false';
-  orderBy: string;
+  orderBy: ReturnUnitSortableField;
   ascending: boolean;
   orderLabel: 'CreatedDate' | 'Name' | 'Status';
   lastRequestSignature?: string;

--- a/src/app/feature-module/administration/supplies/services/supplies-state.service.ts
+++ b/src/app/feature-module/administration/supplies/services/supplies-state.service.ts
@@ -1,5 +1,8 @@
 import { Injectable } from '@angular/core';
-import { SimpleItemViewModel } from '../../../../shared/models/supplies';
+import {
+  SimpleItemViewModel,
+  SupplySortableField,
+} from '../../../../shared/models/supplies';
 
 interface SuppliesListState {
   tableData: SimpleItemViewModel[];
@@ -8,7 +11,7 @@ interface SuppliesListState {
   backendPage: number;
   filtroNome: string;
   filtroAtivo: '' | 'true' | 'false';
-  orderBy: string;
+  orderBy: SupplySortableField;
   ascending: boolean;
   orderLabel: 'CreatedDate' | 'Name' | 'Status';
   lastRequestSignature?: string;

--- a/src/app/feature-module/administration/supplies/supplies/supplies.component.ts
+++ b/src/app/feature-module/administration/supplies/supplies/supplies.component.ts
@@ -4,7 +4,11 @@ import {
   SuppliesApiService,
   ListSuppliesParams,
 } from '../services/supplies.api.service';
-import { SimpleItemViewModel, SupplyType } from '../../../../shared/models/supplies';
+import {
+  SimpleItemViewModel,
+  SupplySortableField,
+  SupplyType,
+} from '../../../../shared/models/supplies';
 import { SuppliesStateService } from '../services/supplies-state.service';
 
 function supplyTypeLabel(type: SupplyType): string {
@@ -60,7 +64,7 @@ export class SuppliesComponent implements OnInit {
   filtroNome = '';
   filtroAtivo: '' | 'true' | 'false' = '';
 
-  orderBy = 'createdAt';
+  orderBy: SupplySortableField = 'createdAt';
   ascending = false;
   orderLabel: 'CreatedDate' | 'Name' | 'Status' = 'CreatedDate';
 
@@ -140,7 +144,7 @@ export class SuppliesComponent implements OnInit {
     this.loadPage();
   }
 
-  private mapOrderField(field: 'CreatedDate' | 'Name' | 'Status'): string {
+  private mapOrderField(field: 'CreatedDate' | 'Name' | 'Status'): SupplySortableField {
     switch (field) {
       case 'Name':
         return 'name';

--- a/src/app/shared/models/api/base-view.model.ts
+++ b/src/app/shared/models/api/base-view.model.ts
@@ -9,7 +9,9 @@ export interface AuditMetadata {
   updatedBy?: string | null;
 }
 
-export interface AuditableViewModel extends EntityIdentifier, AuditMetadata {}
+export interface AuditableViewModel extends EntityIdentifier, AuditMetadata {
+  [key: string]: unknown;
+}
 
 export type SortableKeys<T> = Extract<keyof T, string>;
 

--- a/src/app/shared/models/banks.ts
+++ b/src/app/shared/models/banks.ts
@@ -18,11 +18,11 @@ export interface BankListFilters {
 
 export type ListBanksParams = ListRequestParams<BankSortableField> & BankListFilters;
 
-export type BankListFilterState = {
+export interface BankListFilterState extends Record<string, unknown> {
   name: string;
   bankCode: string;
   isActive: '' | 'true' | 'false';
-};
+}
 
 export const defaultBankListFilterState: BankListFilterState = {
   name: '',

--- a/src/app/shared/models/courier-companies.ts
+++ b/src/app/shared/models/courier-companies.ts
@@ -46,7 +46,7 @@ export interface CourierCompanyListFilters {
 
 export type ListCourierCompaniesParams = ListRequestParams<CourierCompanySortableField> & CourierCompanyListFilters;
 
-export interface CourierCompanyListFilterState {
+export interface CourierCompanyListFilterState extends Record<string, unknown> {
   name: string;
   isActive: '' | 'true' | 'false';
 }

--- a/src/app/shared/models/couriers.ts
+++ b/src/app/shared/models/couriers.ts
@@ -73,7 +73,7 @@ export interface CourierListFilters {
 
 export type ListCouriersParams = ListRequestParams<CourierSortableField> & CourierListFilters;
 
-export interface CourierListFilterState {
+export interface CourierListFilterState extends Record<string, unknown> {
   name: string;
   courierCompanyId: string;
   servedCityId: string;


### PR DESCRIPTION
## Summary
- allow auditable view models to satisfy list state record constraints
- type administration list state services and components with specific sortable fields
- ensure administration list filter state models satisfy shared list state record constraints

## Testing
- npm run build *(fails: ng: not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e149c87b90832fbfa618b0c4af1757