### PR TITLE
docs: detalhar execucao da padronizacao de cadastros

### DIFF
--- a/docs/plano-implementacao-cadastros-angular19.md
+++ b/docs/plano-implementacao-cadastros-angular19.md
@@ -1,0 +1,442 @@
+# Padronização de Cadastros e Código Angular 19
+
+## 1) Diagnóstico resumido
+| Tela / Feature | Divergências identificadas |
+| --- | --- |
+| Laboratórios (lista e formulário) | Listagem mantém labels sem acentuação e filtros `[(ngModel)]` misturados com controles reativos, quebrando consistência e i18n ("Laboratrios", placeholders sem acento). 【F:src/app/feature-module/administration/laboratories/laboratories/laboratories.component.html†L1-L188】 Formulário usa `FormGroup` não tipado, strings sem acento e `*ngIf`, sem mensagens centralizadas ou máscaras. 【F:src/app/feature-module/administration/laboratories/laboratory-upsert/laboratory-upsert.component.ts†L1-L145】【F:src/app/feature-module/administration/laboratories/laboratory-upsert/laboratory-upsert.component.html†L1-L61】 |
+| Unidades de Devolução | Lista trava paginação quando filtro de laboratório está vazio e mistura `[(ngModel)]` com sinais/comportamento reativo, além de manter labels e títulos sem acentos. 【F:src/app/feature-module/administration/return-units/return-units/return-units.component.ts†L31-L206】【F:src/app/feature-module/administration/return-units/return-units/return-units.component.html†L1-L198】 Formulário replica padrões de laboratório, sem form group tipado, sem diretivas de máscara e com `*ngIf` para mensagens. 【F:src/app/feature-module/administration/return-units/return-unit-upsert/return-unit-upsert.component.ts†L1-L120】【F:src/app/feature-module/administration/return-units/return-unit-upsert/return-unit-upsert.component.html†L1-L141】 |
+| Projetos | Estrutura semelhante às demais, ainda com `FormGroup` não tipado, `*ngIf`, campos sem máscara ou consistência de labels, além de selects manuais repetidos para laboratórios. 【F:src/app/feature-module/administration/projects/project-upsert/project-upsert.component.ts†L1-L190】【F:src/app/feature-module/administration/projects/project-upsert/project-upsert.component.html†L1-L120】 |
+| CRM (Companies / Contacts) | Usa `UntypedFormBuilder`, acesso direto ao DOM, modais bootstrap e strings em inglês, destoando dos cadastros principais e das diretrizes Angular 19 (standalone, forms tipados, i18n pt-BR). 【F:src/app/pages/crm/companies/companies.component.ts†L1-L198】【F:src/app/pages/crm/contacts/contacts.component.ts†L1-L188】 |
+| Arquitetura global | App continua baseado em `NgModule`, `provideRouter` ausente, interceptors classe-based com `withInterceptorsFromDi`, sem SSR/hidratação, e estilos globais sem tokens. 【F:src/app/app.module.ts†L1-L85】【F:src/app/app-routing.module.ts†L1-L20】【F:src/main.ts†L1-L14】【F:src/app/core/http/api-feedback.interceptor.ts†L1-L59】【F:src/styles.scss†L1-L50】 |
+
+## 2) Padrões propostos
+1. **Standalone + Providers centralizados**: substituir `AppModule`/`AppRoutingModule` por `bootstrapApplication` com `provideRouter`, `withComponentInputBinding`, `withViewTransitions` e `provideClientHydration` para SSR-ready. 【F:src/app/app.module.ts†L1-L85】【F:src/app/app-routing.module.ts†L1-L20】【F:src/main.ts†L1-L14】
+2. **Form Shell reativo tipado**: usar `FormBuilder.nonNullable` (ou `FormGroup<FormModel>`), validadores reutilizáveis e máscaras via directives para CPF/CNPJ, CEP, telefone; centralizar mensagens via componente único (`FormFieldErrorComponent`). 【F:src/app/feature-module/administration/return-units/return-unit-upsert/return-unit-upsert.component.ts†L31-L118】
+3. **Templates com controle estrutural moderno**: substituir `*ngIf/*ngFor` por `@if/@for/@switch`, aplicar `@defer` em grids pesadas e skeletons padronizados (`LoadingState`). 【F:src/app/feature-module/administration/return-units/return-units/return-units.component.html†L97-L199】
+4. **Normalização de labels/i18n**: corrigir acentuação e mover textos para chaves `i18n` (`pt-BR`), inclusive breadcrumbs, botões e placeholders. 【F:src/app/feature-module/administration/laboratories/laboratories/laboratories.component.html†L1-L188】
+5. **Estados compartilhados e selects reutilizáveis**: extrair combo de laboratórios para componente standalone com `signal` + `@defer`, consumido por Projetos, Unidades e outros cadastros para eliminar duplicações. 【F:src/app/feature-module/administration/projects/project-upsert/project-upsert.component.ts†L88-L189】【F:src/app/feature-module/administration/return-units/return-unit-upsert/return-unit-upsert.component.ts†L68-L120】
+6. **Interceptors funcionais + Http util**: migrar interceptors para `provideHttpClient(withInterceptors([...]))`, usando funções puras e `inject(NotificationService)` onde necessário. 【F:src/app/core/http/api-feedback.interceptor.ts†L1-L59】
+7. **Tema com tokens SCSS**: definir mapa de cores, spacing, tipografia e aplicar BEM/utilitários consistentes, substituindo regras ad-hoc em `styles.scss`. 【F:src/styles.scss†L1-L50】
+8. **Testes mínimos**: configurar `TestBed` sem NgModule, cobrindo validação de forms, serviços HTTP com `HttpClientTesting` e guards/resolvers funcionais.
+
+## 3) Plano de refatoração por feature
+| Feature | Passos | Esforço |
+| --- | --- | --- |
+| **Bootstrap/Arquitetura** | 1. Criar `app/app.config.ts` com `provideRouter`, `provideHttpClient`, `provideClientHydration`, `provideStore` etc. 2. Ajustar `main.ts` para `bootstrapApplication(AppComponent, appConfig)`. 3. Converter interceptors para funções e registrar via `withInterceptors`. | Grande |
+| **Laboratórios** | 1. Extrair `LaboratoryFormShell` standalone usando `FormShellComponent` base. 2. Corrigir i18n/acentos e migrar template para `@if/@for`. 3. Substituir filtros `[(ngModel)]` por signals + `FormControl`. 4. Adicionar testes de validação e estado. | Médio |
+| **Unidades de Devolução** | 1. Reaproveitar `LaboratorySelectComponent`. 2. Normalizar address form com máscara CEP/telefone. 3. Corrigir lógica de filtro (não bloquear sem laboratório). 4. Aplicar `LoadingState` e mensagens padronizadas. | Médio |
+| **Projetos** | 1. Reutilizar shell/form-field components. 2. Separar configurações de estoque em subform tipado. 3. Simplificar toggles com diretivas de acessibilidade. | Médio |
+| **CRM (Companies/Contacts)** | 1. Migrar para standalone, forms tipados e `inject()`. 2. Remover `UntypedForm*`, DOM manual e strings em inglês. 3. Avaliar descontinuação se cadastros legacy não forem usados. | Grande |
+| **Tema/CSS** | 1. Criar `styles/_tokens.scss` com cores, spacing, sombra, radii. 2. Revisar componentes para usar tokens ou utilitários. 3. Implementar variantes dark/light consistentes. | Médio |
+| **Observabilidade/Estados** | 1. Avaliar `signal` + `toSignal` para dados HTTP. 2. Centralizar estados transientes (loading/error) no `FormShellComponent`. | Pequeno |
+
+## 4) Exemplos “antes → depois”
+### Template (`@if/@for` + `@defer`)
+**Antes** (`return-units.component.html`):
+```html
+<select class="form-select" [(ngModel)]="filtroLaboratorio">
+  <option value="">Todos os laboratorios</option>
+  @for (lab of labs; track lab.id) {
+    <option [value]="lab.id">{{ lab.tradeName }}</option>
+  }
+</select>
+<div class="table-responsive table-card">
+  <table class="table align-middle table-nowrap">
+    <tbody>
+      @for (row of tableData; track row) {
+        <tr>...</tr>
+      }
+      @if (carregando) {
+        <tr><td colspan="7">...</td></tr>
+      }
+    </tbody>
+  </table>
+</div>
+```
+**Depois** (sugestão):
+```html
+<app-laboratory-filter
+  [state]="filters().laboratory"
+  (stateChange)="updateLaboratory($event)"
+></app-laboratory-filter>
+@defer (when !loading()) placeholder { <app-loading-state type="table"></app-loading-state> }
+@loading { <app-loading-state type="table"></app-loading-state> }
+@error (let err) { <app-empty-state i18n-message="returnUnits.error" [message]="err"></app-empty-state> }
+@placeholder { <app-loading-state type="table"></app-loading-state> }
+@if (tableRows().length) {
+  <table class="sf-table sf-table--striped">
+    <tbody>
+      @for (row of tableRows(); track row.id) {
+        <tr>...</tr>
+      }
+    </tbody>
+  </table>
+} @else {
+  <app-empty-state i18n-message="returnUnits.empty"></app-empty-state>
+}
+```
+
+### Form (`FormBuilder.nonNullable` + mensagens)
+**Antes** (`return-unit-upsert.component.ts`): usa `FormGroup` genérico sem typing e validação centralizada. 【F:src/app/feature-module/administration/return-units/return-unit-upsert/return-unit-upsert.component.ts†L31-L118】
+
+**Depois** (sugestão):
+```ts
+interface ReturnUnitForm {
+  laboratoryId: FormControl<string>;
+  name: FormControl<string>;
+  legalName: FormControl<string>;
+  tradeName: FormControl<string>;
+  document: FormControl<string>;
+  stateRegistration: FormControl<string | null>;
+  phone: FormControl<string | null>;
+  email: FormControl<string | null>;
+  observation: FormControl<string | null>;
+  isActive: FormControl<boolean>;
+  address: FormGroup<AddressForm>;
+}
+
+readonly form = this.fb.nonNullable.group<ReturnUnitForm>({
+  laboratoryId: this.fb.nonNullable.control('', Validators.required),
+  name: this.fb.nonNullable.control('', [Validators.required, Validators.maxLength(100)]),
+  legalName: this.fb.nonNullable.control('', [Validators.required, Validators.maxLength(100)]),
+  tradeName: this.fb.nonNullable.control('', [Validators.required, Validators.maxLength(100)]),
+  document: this.fb.nonNullable.control('', [Validators.required, cnpjValidator()]),
+  stateRegistration: this.fb.control<string | null>(null, Validators.maxLength(30)),
+  phone: this.fb.control<string | null>(null, phoneValidator()),
+  email: this.fb.control<string | null>(null, Validators.email),
+  observation: this.fb.control<string | null>(null, Validators.maxLength(1000)),
+  isActive: this.fb.nonNullable.control(true),
+  address: buildAddressGroup(this.fb),
+});
+```
+
+### CSS (tokens + utilitários)
+**Antes**: estilos dispersos sem tokens e com comentários duplicados. 【F:src/styles.scss†L1-L50】
+
+**Depois**:
+```scss
+// styles/_tokens.scss
+$sf-colors: (
+  primary: #2563eb,
+  primary-contrast: #ffffff,
+  surface: #ffffff,
+  surface-alt: #f8fafc,
+  border: #dbe2ef,
+  danger: #dc2626,
+);
+$sf-spacing: (xs: 0.25rem, sm: 0.5rem, md: 1rem, lg: 1.5rem, xl: 2rem);
+
+// styles.scss
+@use 'styles/tokens' as *;
+.sf-card {
+  border-radius: map-get($sf-radius, md);
+  box-shadow: map-get($sf-shadows, sm);
+  background-color: map-get($sf-colors, surface);
+}
+```
+
+### Router/Providers (`app.config.ts`)
+```ts
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideClientHydration(),
+    provideRouter(appRoutes, withComponentInputBinding(), withViewTransitions()),
+    provideHttpClient(withFetch(), withInterceptors([authInterceptor, apiFeedbackInterceptor])),
+    provideStore(),
+    provideEffects(),
+    provideAnimations(),
+  ],
+};
+```
+
+### Interceptor funcional
+```ts
+export const apiFeedbackInterceptor: HttpInterceptorFn = (req, next) => {
+  const notification = inject(NotificationService);
+  if (isMutation(req)) {
+    notification.clearValidationErrors();
+  }
+  return next(req).pipe(
+    tap((event) => maybeNotifySuccess(event, req, notification)),
+    catchError((error: HttpErrorResponse) => {
+      if (req.context.get(SKIP_ERROR_TOAST)) {
+        return throwError(() => error);
+      }
+      const normalized = notification.handleHttpError(error);
+      return throwError(() => normalized);
+    })
+  );
+};
+```
+
+## 5) Diffs sugeridos
+```patch
+*** a/src/main.ts
+--- b/src/main.ts
+@@
+-import { enableProdMode } from '@angular/core';
+-import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+-
+-import { AppModule } from './app/app.module';
+-import { environment } from './environments/environment';
+-
+-if (environment.production) {
+-  enableProdMode();
+-}
+-
+-platformBrowserDynamic().bootstrapModule(AppModule)
+-  .catch(err => console.error(err));
++import { bootstrapApplication } from '@angular/platform-browser';
++import { AppComponent } from './app/app.component';
++import { appConfig } from './app/app.config';
++
++bootstrapApplication(AppComponent, appConfig).catch((err) => console.error(err));
+```
+
+```patch
+*** /dev/null
+--- b/src/app/app.config.ts
++import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
++import { provideRouter, withComponentInputBinding, withViewTransitions } from '@angular/router';
++import { provideClientHydration } from '@angular/platform-browser';
++import { provideHttpClient, withFetch, withInterceptors } from '@angular/common/http';
++import { appRoutes } from './app.routes';
++import { apiFeedbackInterceptor } from './core/http/api-feedback.interceptor';
++import { authInterceptor } from './auth/keycloak/token.interceptor';
++
++export const appConfig: ApplicationConfig = {
++  providers: [
++    provideZoneChangeDetection({ eventCoalescing: true }),
++    provideClientHydration(),
++    provideRouter(appRoutes, withComponentInputBinding(), withViewTransitions()),
++    provideHttpClient(withFetch(), withInterceptors([authInterceptor, apiFeedbackInterceptor])),
++  ],
++};
+```
+
+```patch
+*** a/src/app/core/http/api-feedback.interceptor.ts
+--- b/src/app/core/http/api-feedback.interceptor.ts
+@@
+-import { Injectable } from '@angular/core';
+-import {
+-  HttpErrorResponse,
+-  HttpEvent,
+-  HttpHandler,
+-  HttpInterceptor,
+-  HttpRequest,
+-  HttpResponse,
+-} from '@angular/common/http';
+-import { Observable, catchError, tap, throwError } from 'rxjs';
+-import { NotificationService } from '../notifications/notification.service';
+-import { SKIP_ERROR_TOAST, SKIP_SUCCESS_TOAST, SUCCESS_MESSAGE } from './http-context.tokens';
+-
+-@Injectable()
+-export class ApiFeedbackInterceptor implements HttpInterceptor {
+-  private readonly mutationMethods = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+-
+-  constructor(private readonly notification: NotificationService) {}
+-
+-  intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+-    const method = req.method.toUpperCase();
+-    if (this.mutationMethods.has(method)) {
+-      this.notification.clearValidationErrors();
+-    }
+-
+-    return next.handle(req).pipe(
+-      tap(event => {
+-        if (event instanceof HttpResponse && this.shouldNotifySuccess(method, req, event)) {
+-          const message = this.resolveSuccessMessage(method, req, event);
+-          this.notification.clearValidationErrors();
+-          this.notification.success(message);
+-        }
+-      }),
+-      catchError((error: HttpErrorResponse) => {
+-        if (req.context.get(SKIP_ERROR_TOAST)) {
+-          return throwError(() => error);
+-        }
+-        const normalized = this.notification.handleHttpError(error);
+-        return throwError(() => normalized);
+-      })
+-    );
+-  }
++import { inject } from '@angular/core';
++import { HttpErrorResponse, HttpInterceptorFn, HttpResponse } from '@angular/common/http';
++import { catchError, tap, throwError } from 'rxjs';
++import { NotificationService } from '../notifications/notification.service';
++import { SKIP_ERROR_TOAST, SKIP_SUCCESS_TOAST, SUCCESS_MESSAGE } from './http-context.tokens';
++
++const MUTATION_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
++
++export const apiFeedbackInterceptor: HttpInterceptorFn = (req, next) => {
++  const notification = inject(NotificationService);
++  const method = req.method.toUpperCase();
++
++  if (MUTATION_METHODS.has(method)) {
++    notification.clearValidationErrors();
++  }
++
++  return next(req).pipe(
++    tap((event) => {
++      if (event instanceof HttpResponse && shouldNotifySuccess(method, req, event)) {
++        const message = resolveSuccessMessage(method, req, event);
++        notification.clearValidationErrors();
++        notification.success(message);
++      }
++    }),
++    catchError((error: HttpErrorResponse) => {
++      if (req.context.get(SKIP_ERROR_TOAST)) {
++        return throwError(() => error);
++      }
++      const normalized = notification.handleHttpError(error);
++      return throwError(() => normalized);
++    })
++  );
++};
+```
+
+## 6) Snippets reutilizáveis
+### `FormShellComponent`
+```ts
+@Component({
+  selector: 'app-form-shell',
+  standalone: true,
+  template: `
+    <form [formGroup]="form" (ngSubmit)="onSubmit()" novalidate>
+      <ng-content></ng-content>
+      <div class="sf-form__actions">
+        <button type="button" class="btn btn-outline-secondary" (click)="cancel.emit()">{{ cancelLabel }}</button>
+        @if (!readonly()) {
+          <button type="submit" class="btn btn-primary" [disabled]="loading() || form.invalid">
+            {{ loading() ? loadingLabel : submitLabel }}
+          </button>
+        }
+      </div>
+    </form>
+  `,
+  imports: [ReactiveFormsModule],
+})
+export class FormShellComponent<T extends AbstractControl> {
+  readonly form = input.required<FormGroup<T>>();
+  readonly loading = input<boolean>(false);
+  readonly readonly = input<boolean>(false);
+  readonly submitLabel = input('Salvar');
+  readonly loadingLabel = input('Salvando...');
+  readonly cancelLabel = input('Cancelar');
+  readonly submitted = signal(false);
+  readonly cancel = output<void>();
+  readonly submit = output<FormGroup<T>>();
+
+  onSubmit(): void {
+    this.submitted.set(true);
+    if (this.form().invalid) {
+      this.form().markAllAsTouched();
+      return;
+    }
+    this.submit.emit(this.form());
+  }
+}
+```
+
+### `FormFieldErrorComponent`
+```ts
+@Component({
+  selector: 'app-form-field-error',
+  standalone: true,
+  template: `
+    @if (control().invalid && (control().dirty || control().touched || submitted())) {
+      <p class="sf-form-field__error" id="{{ for }}-error">
+        {{ resolveMessage() }}
+      </p>
+    }
+  `,
+})
+export class FormFieldErrorComponent {
+  readonly control = input.required<AbstractControl>();
+  readonly for = input.required<string>();
+  readonly submitted = input<boolean>(false);
+  readonly messages = input<Record<string, string>>({ required: $localize`Campo obrigatório.` });
+
+  resolveMessage(): string {
+    const errors = this.control().errors ?? {};
+    const key = Object.keys(errors)[0];
+    return this.messages()[key] ?? $localize`Campo inválido.`;
+  }
+}
+```
+
+### `HttpErrorInterceptor` funcional
+```ts
+export const httpErrorInterceptor: HttpInterceptorFn = (req, next) => {
+  const notifications = inject(NotificationService);
+  return next(req).pipe(
+    catchError((error: HttpErrorResponse) => {
+      notifications.error(resolveErrorMessage(error));
+      return throwError(() => error);
+    })
+  );
+};
+```
+
+### `LoadingState`
+```ts
+@Component({
+  selector: 'app-loading-state',
+  standalone: true,
+  template: `
+    @switch (type()) {
+      @case ('table') { <div class="sf-skeleton sf-skeleton--table"></div> }
+      @case ('form') { <div class="sf-skeleton sf-skeleton--form"></div> }
+      @default { <div class="spinner-border" role="status"><span class="visually-hidden">Carregando...</span></div> }
+    }
+  `,
+})
+export class LoadingStateComponent {
+  readonly type = input<'table' | 'form' | 'inline'>('inline');
+}
+```
+
+### `useCrudResource<T>()`
+```ts
+export function useCrudResource<T>(fetcher: () => Observable<T[]>) {
+  const loading = signal(true);
+  const error = signal<string | null>(null);
+  const data = signal<T[]>([]);
+
+  const refresh = () => {
+    loading.set(true);
+    error.set(null);
+    fetcher().subscribe({
+      next: (items) => {
+        data.set(items);
+        loading.set(false);
+      },
+      error: (err) => {
+        error.set(err?.message ?? 'Erro ao carregar dados.');
+        loading.set(false);
+      },
+    });
+  };
+
+  refresh();
+  return { data, loading, error, refresh };
+}
+```
+
+## 7) Riscos / Observações
+- **Migração para standalone** exige revisar módulos third-party (`ng-bootstrap`, `ngx-pipes`, `primeng`). Confirmar se oferecem providers standalone ou avaliar lazy providers separados. 【F:src/app/app.module.ts†L1-L85】
+- **SSR/Hidratação**: validar compatibilidade de bibliotecas que manipulam `window/document` (ex.: `ngx-csv`, `sweetalert2`) e aplicar `isPlatformBrowser` quando necessário.
+- **Máscaras/validações**: caso não exista biblioteca atual, considerar diretivas customizadas para CPF/CNPJ/CEP antes de adicionar dependências.
+- **Estado legado NgRx**: ajustar bootstrap via `provideStore`/`provideEffects` mantendo slices existentes.
+- **Internacionalização**: revisar `TranslateModule` para inicializar via `provideTranslate` (ou alternativa) sem `NgModule`.
+
+## 8) Checklist final
+- [ ] Standalone + `bootstrapApplication` configurados.
+- [ ] Rotas tipadas com `provideRouter` e view transitions.
+- [ ] Forms de cadastros usando `FormShellComponent`, `FormFieldErrorComponent` e validação consistente.
+- [ ] Campos com labels, placeholders e mensagens acentuados e traduzidos.
+- [ ] Componentes de filtro/lista com `@if/@for`, `@defer` e estados padronizados (`LoadingState`).
+- [ ] Interceptors funcionais registrados via `provideHttpClient(withInterceptors)`.
+- [ ] Tokens de design (`styles/_tokens.scss`) aplicados.
+- [ ] Testes unitários para forms, services e rotas atualizados para standalone.

--- a/docs/plano-refatoracao-angular19.md
+++ b/docs/plano-refatoracao-angular19.md
@@ -1,0 +1,375 @@
+# Plano de Padronização Angular 19
+
+## 1) **Diagnóstico resumido**
+| Tela / Domínio | Principais divergências |
+| --- | --- |
+| `account/register` (Cadastro de usuário) | Usa `UntypedFormGroup` e `UntypedFormBuilder`; sem standalone; campos sem máscaras/validações coerentes; mensagens duplicadas e em inglês; submissão ignora estado inválido. 【F:src/app/account/register/register.component.ts†L1-L96】 |
+| `pages/ecommerce/add-product` (Cadastro de produto) | Template extensivo com inputs soltos, sem formulário reativo, sem acessibilidade ou i18n; mistura `ngbNav` e componentes externos sem lazy; campos e textos em inglês. 【F:src/app/pages/ecommerce/add-product/add-product.component.html†L1-L200】 |
+| `feature/administration/laboratories/laboratory-upsert` | Apesar de standalone, mantém strings sem acento ("Laboratorio"), validação duplicada e sem tipos estritos; falta componetização para estados e mensagens. 【F:src/app/feature-module/administration/laboratories/laboratory-upsert/laboratory-upsert.component.ts†L1-L170】 |
+| `feature/administration/projects/project-upsert` | Estrutura semelhante, porém textos divergentes e sem i18n; ausência de máscaras e validações específicas por campo; ordenação de campos difere de laboratórios. 【F:src/app/feature-module/administration/projects/project-upsert/project-upsert.component.ts†L1-L200】 |
+| `feature/administration/return-units/return-unit-upsert` | Campos endereços sem máscaras, estados carregados manualmente, mensagens hardcoded; ordem de campos difere das demais telas; títulos sem acentuação. 【F:src/app/feature-module/administration/return-units/return-unit-upsert/return-unit-upsert.component.ts†L1-L200】 |
+| Listagens relacionadas (`projects`, `return-units`) | Filtros `[(ngModel)]` misturados com forms reativos; duplicação de select de laboratórios; colunas com acentuação incorreta ("Laboratorio"). 【F:src/app/feature-module/administration/projects/projects/projects.component.html†L43-L113】【F:src/app/feature-module/administration/return-units/return-units/return-units.component.html†L43-L113】 |
+| Global (`styles.scss`, roteamento, interceptors) | SCSS com estilos soltos, sem tokens; `AppModule` ainda presente; interceptors classe-based com DI tradicional; ausência de `provideRouter` com rotas tipadas; problemas de acentuação em breadcrumbs ("Laboratrios"). 【F:src/styles.scss†L1-L76】【F:src/app/app.module.ts†L1-L104】【F:src/app/layouts/sidebar/menu.ts†L22-L35】【F:src/app/feature-module/administration/laboratories/laboratories/laboratories.component.html†L1-L9】
+
+## 2) **Padrões propostos**
+1. **Arquitetura standalone**: migrar `AppModule`/`feature-module` para `app.config.ts` com `provideRouter`, `withComponentInputBinding`, `withViewTransitions`, SSR (`provideClientHydration`) e `provideHttpClient(withInterceptors([...]))` com interceptors funcionais.
+2. **Camada de formulários**: adotar `FormBuilder.nonNullable`, `FormGroup` tipados (`type FormModel = ReturnType<...>`), validações centralizadas e mensagens via `FormFieldErrorComponent` reutilizável.
+3. **Fluxo de template**: substituir `*ngIf/*ngFor` por `@if/@for`, usar `@defer` para grids, centralizar estados (loading/empty/error) em `LoadingStateComponent`.
+4. **Design tokens**: definir `tokens.scss` com cores/tipografia/spacing; componentes usam BEM (`.form-shell__actions`).
+5. **i18n e acentuação**: textos em pt-BR via `i18n` pipe (`{{ 'cadastro.produto.titulo' | i18n }}`) e correção de caracteres.
+6. **Serviços/HTTP**: converter interceptors para funções (`export const httpErrorInterceptor = (req, next) => ...`), consolidar `useCrudResource<T>()` com sinais e `HttpClient` tipado.
+7. **Padronização de cadastros**: componentes `FormShellComponent` e `FormFieldComponent` (label + input + hint + erro), ações fixas (Salvar/Cancelar) com ícones.
+8. **Testes mínimos**: `*.spec.ts` com `TestBed` standalone, validando formulários e interceptors.
+
+## 3) **Plano de refatoração por feature**
+1. **Base do app (Grande)**
+   - Criar `app.config.ts` com `provideRouter`, interceptors funcionais e `provideClientHydration`.
+   - Remover `AppModule`, migrar providers e bootstrap via `bootstrapApplication`.
+   - Configurar `prettier` + `lint-staged` e scripts (`format`, `lint`).
+2. **Design System (Médio)**
+   - Criar `src/app/shared/ui/form-shell` com tokens SCSS e componentes reutilizáveis.
+   - Normalizar `styles.scss` para importar tokens/utilitários.
+3. **Cadastros Administração (Grande)**
+   - `Laboratory`, `Project`, `ReturnUnit`: alinhar estrutura de formulário (ordem, labels, validações), i18n e uso de `FormShellComponent`; extrair selects compartilhados (laboratory combo) para componente.
+   - Ajustar listagens para usar componentes de estado e `@defer`.
+4. **Cadastros Ecommerce/Account (Médio)**
+   - Reescrever `register`, `add-product` com forms reativos tipados, i18n e padronização de mensagens.
+   - Criar máscara directives (CPF/CNPJ, CEP, telefone) reutilizáveis.
+5. **Services/Interceptors (Médio)**
+   - Converter interceptors para funções, eliminar `HTTP_INTERCEPTORS` array.
+   - Implementar `useCrudResource<T>()` para encapsular chamadas e sinais (loading/error/data).
+6. **Automação/Testes (Pequeno)**
+   - Adicionar testes unitários para formulários (validadores) e interceptors funcionais.
+   - Configurar Git hooks via Husky (opcional) para format/lint.
+
+## 4) **Exemplos “antes → depois”**
+### Template (`laboratory-upsert`)
+- **Antes**
+  ```html
+  <h5 class="card-title mb-0">Lista de Laboratrios</h5>
+  <button type="button" class="btn btn-success" (click)="save()">Salvar</button>
+  ```
+- **Depois**
+  ```html
+  <app-form-shell title="{{ 'laboratory.form.title' | i18n }}" [loading]="loading()">
+    <form [formGroup]="form" (ngSubmit)="onSubmit()">
+      @for (field of fields; track field.controlName) {
+        <app-form-field [config]="field"></app-form-field>
+      }
+      <app-form-shell-actions (cancel)="onCancel()"></app-form-shell-actions>
+    </form>
+  </app-form-shell>
+  ```
+
+### Form (`register.component.ts`)
+- **Antes**
+  ```ts
+  this.signupForm = this.formBuilder.group({
+    email: ['', [Validators.required, Validators.email]],
+    name: ['', [Validators.required]],
+    password: ['', Validators.required],
+  });
+  ```
+- **Depois**
+  ```ts
+  type RegisterFormModel = {
+    name: FormControl<string>;
+    email: FormControl<string>;
+    password: FormControl<string>;
+  };
+
+  readonly form = this.fb.nonNullable.group<RegisterFormModel>({
+    name: this.fb.nonNullable.control('', {
+      validators: [Validators.required, Validators.maxLength(120)],
+    }),
+    email: this.fb.nonNullable.control('', {
+      validators: [Validators.required, Validators.email],
+    }),
+    password: this.fb.nonNullable.control('', {
+      validators: [Validators.required, Validators.minLength(8)],
+    }),
+  });
+  ```
+
+### CSS / Tokens
+- **Antes**
+  ```scss
+  .card-title {
+    color: #3577f1;
+  }
+  ```
+- **Depois**
+  ```scss
+  @use 'src/styles/tokens' as tokens;
+
+  .form-shell {
+    &__title {
+      color: tokens.$color-primary-600;
+      margin-bottom: tokens.$space-6;
+    }
+  }
+  ```
+
+### Router / Providers
+- **Antes**
+  ```ts
+  @NgModule({
+    imports: [RouterModule.forRoot(routes)],
+    exports: [RouterModule],
+  })
+  export class AppRoutingModule {}
+  ```
+- **Depois**
+  ```ts
+  export const appConfig: ApplicationConfig = {
+    providers: [
+      provideRouter(appRoutes, withComponentInputBinding(), withViewTransitions()),
+      provideClientHydration(),
+      provideHttpClient(withInterceptors([authInterceptor, httpErrorInterceptor])),
+    ],
+  };
+  ```
+
+### Interceptor funcional
+- **Antes**
+  ```ts
+  @Injectable()
+  export class ApiFeedbackInterceptor implements HttpInterceptor {
+    intercept(req: HttpRequest<unknown>, next: HttpHandler) {
+      return next.handle(req).pipe(tap({ error: (err) => notify(err) }));
+    }
+  }
+  ```
+- **Depois**
+  ```ts
+  export const apiFeedbackInterceptor: HttpInterceptorFn = (req, next) =>
+    next(req).pipe(
+      tap({
+        error: (error) => inject(NotificationService).error(mapHttpError(error)),
+      })
+    );
+  ```
+
+## 5) **Diffs sugeridos**
+```patch
+*** a/src/app/account/register/register.component.ts
+--- b/src/app/account/register/register.component.ts
+@@
+-import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
++import { FormBuilder, FormControl, Validators } from '@angular/forms';
+@@
+-  signupForm!: UntypedFormGroup;
++  readonly form = this.fb.nonNullable.group({
++    name: this.fb.nonNullable.control('', {
++      validators: [Validators.required, Validators.maxLength(120)],
++    }),
++    email: this.fb.nonNullable.control('', {
++      validators: [Validators.required, Validators.email],
++    }),
++    password: this.fb.nonNullable.control('', {
++      validators: [Validators.required, Validators.minLength(8)],
++    }),
++  });
+@@
+-    this.authenticationService.register(this.f['email'].value, this.f['name'].value, this.f['password'].value)
++    if (this.form.invalid) {
++      this.form.markAllAsTouched();
++      return;
++    }
++
++    const { email, name, password } = this.form.getRawValue();
++    this.authenticationService.register(email, name, password)
+       .pipe(first())
+       .subscribe({
+         next: () => this.router.navigate(['/auth/login']),
+-        error: (error: any) => {
+-          this.error = error ? error : '';
+-        }
++        error: (error: any) => (this.error = error ?? ''),
+       });
+```
+
+```patch
+*** a/src/app/pages/ecommerce/add-product/add-product.component.html
+--- b/src/app/pages/ecommerce/add-product/add-product.component.html
+@@
+-    <form>
+-        <div class="card">
+-            <div class="card-body">
+-                <div class="mb-3">
+-                    <label class="form-label" for="product-title-input">Product Title</label>
+-                    <input type="text" class="form-control" id="product-title-input" placeholder="Enter product title">
+-                </div>
+-                <div>
+-                    <label>Product Description</label>
+-                    <ckeditor [editor]="Editor" data="..."></ckeditor>
+-                </div>
+-            </div>
+-        </div>
+-        <!-- ... -->
+-    </form>
++    <app-form-shell
++      title="{{ 'ecommerce.product.create.title' | i18n }}"
++      subtitle="{{ 'ecommerce.product.create.subtitle' | i18n }}"
++      [loading]="loading()"
++    >
++      <form [formGroup]="form" (ngSubmit)="onSubmit()" autocomplete="off">
++        @for (section of sections; track section.id) {
++          <app-form-section [config]="section"></app-form-section>
++        }
++        <app-form-shell-actions (cancel)="onCancel()"></app-form-shell-actions>
++      </form>
++    </app-form-shell>
+```
+
+```patch
+*** a/src/app/app.module.ts
+--- /dev/null
+@@
+-@NgModule({
+-  declarations: [AppComponent],
+-  imports: [BrowserModule, AppRoutingModule, HttpClientModule],
+-  providers: [
+-    { provide: HTTP_INTERCEPTORS, useClass: AccessControlInterceptor, multi: true },
+-    { provide: HTTP_INTERCEPTORS, useClass: TokenInterceptor, multi: true },
+-    provideHttpClient(withInterceptorsFromDi()),
+-  ],
+-  bootstrap: [AppComponent],
+-})
+-export class AppModule {}
+```
+
+```patch
+*** /dev/null
+--- b/src/app/app.config.ts
+@@
++import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
++import { provideRouter, withComponentInputBinding, withViewTransitions } from '@angular/router';
++import { provideClientHydration } from '@angular/platform-browser';
++import { provideHttpClient, withInterceptors } from '@angular/common/http';
++import { appRoutes } from './app.routes';
++import { authInterceptor } from './core/http/auth.interceptor';
++import { apiFeedbackInterceptor } from './core/http/api-feedback.interceptor';
++
++export const appConfig: ApplicationConfig = {
++  providers: [
++    provideZoneChangeDetection({ eventCoalescing: true }),
++    provideRouter(appRoutes, withComponentInputBinding(), withViewTransitions()),
++    provideClientHydration(),
++    provideHttpClient(withInterceptors([authInterceptor, apiFeedbackInterceptor])),
++  ],
++};
+```
+
+## 6) **Snippets reutilizáveis**
+```ts
+// form-shell.component.ts
+@Component({
+  selector: 'app-form-shell',
+  standalone: true,
+  templateUrl: './form-shell.component.html',
+  styleUrls: ['./form-shell.component.scss'],
+})
+export class FormShellComponent {
+  @Input({ required: true }) title!: string;
+  @Input() subtitle?: string;
+  @Input() loading = false;
+}
+```
+
+```ts
+// form-field-error.component.ts
+@Component({
+  selector: 'app-form-field-error',
+  standalone: true,
+  template: `
+    @if (control.invalid && (control.dirty || control.touched)) {
+      <ul class="form-field-error" role="alert" [attr.aria-live]="'polite'">
+        @for (error of errors(); track error) {
+          <li>{{ error | i18n }}</li>
+        }
+      </ul>
+    }
+  `,
+})
+export class FormFieldErrorComponent {
+  private i18n = inject(I18nService);
+  @Input({ required: true }) control!: AbstractControl;
+  errors = computed(() => this.i18n.resolveErrors(this.control.errors));
+}
+```
+
+```ts
+// http-error.interceptor.ts
+export const httpErrorInterceptor: HttpInterceptorFn = (req, next) =>
+  next(req).pipe(
+    catchError((error: HttpErrorResponse) => {
+      inject(NotificationService).error(mapHttpError(error));
+      return throwError(() => error);
+    })
+  );
+```
+
+```ts
+// loading-state.component.ts
+@Component({
+  selector: 'app-loading-state',
+  standalone: true,
+  template: `
+    @switch (state()) {
+      @case ('loading') { <app-skeleton></app-skeleton> }
+      @case ('error') {
+        <div class="state state--error">
+          {{ message | i18n }}
+          <button type="button" class="btn btn-link" (click)="retry.emit()">{{ 'acoes.tentarNovamente' | i18n }}</button>
+        </div>
+      }
+      @case ('empty') { <div class="state state--empty">{{ emptyMessage | i18n }}</div> }
+    }
+  `,
+})
+export class LoadingStateComponent {
+  state = signal<'loading' | 'error' | 'empty' | 'content'>('content');
+  @Input() message = 'estado.erro.generico';
+  @Input() emptyMessage = 'estado.vazio.generico';
+  @Output() retry = new EventEmitter<void>();
+}
+```
+
+```ts
+// use-crud-resource.ts
+export function useCrudResource<T>(source: () => Observable<T>) {
+  const data = signal<T | null>(null);
+  const loading = signal(false);
+  const error = signal<unknown>(null);
+
+  const refresh = () => {
+    loading.set(true);
+    error.set(null);
+    source()
+      .pipe(finalize(() => loading.set(false)))
+      .subscribe({
+        next: (value) => data.set(value),
+        error: (err) => error.set(err),
+      });
+  };
+
+  return { data: readonlySignal(data), loading: readonlySignal(loading), error: readonlySignal(error), refresh };
+}
+```
+
+## 7) **Riscos / observações**
+- Migração para standalone exige atualizar todos os imports/rotas; planejar sprint específica.
+- Interceptores funcionais dependem do Angular 16+; confirmar versão real do projeto antes da migração.
+- `ckeditor`, `dropzone`, `flatpickr` precisam de wrappers compatíveis com SSR e `@defer`.
+- Possível impacto nos testes E2E devido a novos componentes/layout.
+- Charsets: garantir `meta charset="utf-8"` e que arquivos estejam em UTF-8; revisar dados vindos da API (ex.: labels "Laboratórios").
+
+## 8) **Checklist final**
+- [ ] App configurado via `app.config.ts` com providers modernos.
+- [ ] Formulários reescritos com `FormShellComponent` + mensagens padronizadas.
+- [ ] Campos e mensagens revisados com i18n pt-BR e acentuação correta.
+- [ ] Interceptores funcionais registrados com `provideHttpClient(withInterceptors([...]))`.
+- [ ] Estados de loading/erro/vazio unificados (`LoadingStateComponent`).
+- [ ] Scripts `format`/`lint` com Prettier executando no CI.
+- [ ] Testes unitários mínimos para formulários e interceptors.


### PR DESCRIPTION
## Summary
- documentei diagnóstico resumido das telas de cadastro e arquitetura destacando divergências com Angular 19
- propus padrões, plano de refatoração, exemplos antes/depois, diffs sugeridos e snippets reutilizáveis
- elenquei riscos, observações e checklist final para guiar a execução das melhorias

## Testing
- not run (documentação)

------
https://chatgpt.com/codex/tasks/task_e_68e43f81b060832f83ca6c1abadaafa7