### PR TITLE
Fix loading overlay imports and courier signals

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,9 +134,8 @@
     "karma-jasmine-html-reporter": "^2.1.0",
     "prettier": "^3.6.2",
     "prettier-plugin-organize-imports": "^4.3.0",
-    "simple-git-hooks": "^2.13.1",
-    "typescript": "~5.8.3",
-    "simple-git-hooks": "^2.9.0"
+    "simple-git-hooks": "^2.9.0",
+    "typescript": "~5.8.3"
   },
   "browserslist": [
     "last 1 version",

--- a/src/app/feature-module/administration/courier-companies/courier-company-upsert/courier-company-upsert.component.ts
+++ b/src/app/feature-module/administration/courier-companies/courier-company-upsert/courier-company-upsert.component.ts
@@ -10,6 +10,7 @@ import {
   CourierCompanyInput,
   CourierCompanyViewModel,
 } from '../../../../shared/models/courier-companies';
+import { LoadingOverlayComponent } from '../../../../shared/common/loading-overlay/loading-overlay.component';
 import { SharedModule } from '../../../../shared/shared.module';
 import { createLoadingTracker } from '../../../../shared/utils/loading-tracker';
 import { CourierCompaniesStateService } from '../services/courier-companies-state.service';

--- a/src/app/feature-module/administration/couriers/courier-upsert/courier-upsert.component.ts
+++ b/src/app/feature-module/administration/couriers/courier-upsert/courier-upsert.component.ts
@@ -70,6 +70,20 @@ export class CourierUpsertComponent implements OnInit {
 
   isSaving = signal(false);
   errorMessage = signal<string | null>(null);
+  private loadingTracker = createLoadingTracker();
+  readonly isLoading = this.loadingTracker.isLoading;
+  readonly isBusy = computed(() => this.isSaving() || this.loadingTracker.isLoading());
+  readonly loadingMessage = computed(() => {
+    if (this.isSaving()) {
+      return this.id() ? 'Atualizando entregador...' : 'Salvando entregador...';
+    }
+    if (this.loadingTracker.isLoading()) {
+      return this.id()
+        ? 'Carregando dados do entregador...'
+        : 'Carregando recursos do entregador...';
+    }
+    return 'Processando...';
+  });
 
   states: StateSimpleViewModel[] = [];
   cities: CitySimpleViewModel[] = [];

--- a/src/app/feature-module/administration/user-management/user-upsert/user-upsert.component.ts
+++ b/src/app/feature-module/administration/user-management/user-upsert/user-upsert.component.ts
@@ -15,6 +15,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { ActivatedRoute, Router } from '@angular/router';
 import { GlobalLoaderService } from '../../../../shared/common/global-loader.service';
+import { LoadingOverlayComponent } from '../../../../shared/common/loading-overlay/loading-overlay.component';
 import { RoleViewModel } from '../../../../shared/models/users';
 import { SharedModule } from '../../../../shared/shared.module';
 import { createLoadingTracker } from '../../../../shared/utils/loading-tracker';


### PR DESCRIPTION
## Summary
- import the shared LoadingOverlayComponent in administration upsert components that render it
- add busy/loading computed signals to the courier upsert component so the overlay bindings compile
- clean up the duplicate simple-git-hooks devDependency entry in package.json

## Testing
- npm run build *(fails: external font download is blocked in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e490a0a130832faee74c177ef354f8