### PR TITLE
Use Keycloak logout flow from topbar

### DIFF
--- a/src/app/layouts/topbar/topbar.component.ts
+++ b/src/app/layouts/topbar/topbar.component.ts
@@ -1,6 +1,5 @@
 import { DOCUMENT } from '@angular/common';
 import { Component, EventEmitter, Inject, OnDestroy, OnInit, Output } from '@angular/core';
-import { Router } from '@angular/router';
 import { KeycloakAuthService } from '../../auth/keycloak/keycloak.service';
 import { AuthenticationService } from '../../core/services/auth.service';
 import { TokenStorageService } from '../../core/services/token-storage.service';
@@ -25,7 +24,6 @@ export class TopbarComponent implements OnInit, OnDestroy {
   constructor(
     @Inject(DOCUMENT) private document: Document,
     private authService: AuthenticationService,
-    private router: Router,
     private tokenStorage: TokenStorageService,
     private keycloak: KeycloakAuthService,
   ) {}
@@ -239,7 +237,7 @@ export class TopbarComponent implements OnInit, OnDestroy {
 
   logout(): void {
     this.authService.logout();
-    this.router.navigate(['/auth/login']);
+    this.keycloak.logout(window.location.origin);
   }
 
   windowScroll(): void {


### PR DESCRIPTION
## Summary
- use the shared KeycloakAuthService to handle the topbar logout so the redirect goes through Keycloak instead of the local /auth/login route
- remove the now-unused Router dependency from the topbar component

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5102f15b0832fa6fa9d35811c5325