### PR TITLE
Restrict user management menu and enforce login redirect

### DIFF
--- a/src/app/core/access-control/permission.guard.ts
+++ b/src/app/core/access-control/permission.guard.ts
@@ -13,6 +13,7 @@ import {
 } from '@angular/router';
 import { Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { KeycloakAuthService } from '../../auth/keycloak/keycloak.service';
 import { AccessControlService } from './access-control.service';
 import { PermissionInput } from './access-control.types';
 
@@ -21,36 +22,89 @@ export class PermissionGuard implements CanActivate, CanActivateChild, CanMatch 
   constructor(
     private readonly access: AccessControlService,
     private readonly router: Router,
+    private readonly keycloak: KeycloakAuthService,
   ) {}
 
   canActivate(
     route: ActivatedRouteSnapshot,
     state: RouterStateSnapshot,
   ): Observable<boolean | UrlTree> {
-    return this.evaluate(route.data, route.data?.['permission']);
+    return this.evaluate(route.data, route.data?.['permission'], state.url);
   }
 
   canActivateChild(
     childRoute: ActivatedRouteSnapshot,
     state: RouterStateSnapshot,
   ): Observable<boolean | UrlTree> {
-    return this.evaluate(childRoute.data, childRoute.data?.['permission']);
+    return this.evaluate(childRoute.data, childRoute.data?.['permission'], state.url);
   }
 
   canMatch(route: Route, segments: UrlSegment[]): Observable<boolean | UrlTree> {
-    return this.evaluate(route.data, route.data?.['permission']);
+    const targetUrl = '/' + segments.map((segment) => segment.path).join('/');
+    return this.evaluate(route.data, route.data?.['permission'], targetUrl);
   }
 
   private evaluate(
     data: Data | undefined,
     permission: PermissionInput | undefined,
+    targetUrl?: string,
   ): Observable<boolean | UrlTree> {
-    if (!permission) return of(true);
+    if (!permission) {
+      this.clearPendingLoginRedirect();
+      return of(true);
+    }
     const mode = (data?.['permissionMode'] as 'any' | 'all') === 'any' ? 'any' : 'all';
     const resolver =
       mode === 'any' ? this.access.resolveOnce(permission) : this.access.resolveAllOnce(permission);
     return resolver.pipe(
-      map((allowed) => (allowed ? true : this.router.parseUrl(this.access.getFallbackRoute()))),
+      map((allowed) => {
+        if (allowed) {
+          this.clearPendingLoginRedirect();
+          return true;
+        }
+
+        if (!this.hasPendingLoginRedirect()) {
+          this.markPendingLoginRedirect();
+          const redirectUri = this.buildRedirectUri(targetUrl);
+          this.keycloak.login(redirectUri);
+          return false;
+        }
+
+        this.clearPendingLoginRedirect();
+        return this.router.parseUrl(this.access.getFallbackRoute());
+      }),
     );
   }
+
+  private hasPendingLoginRedirect(): boolean {
+    if (typeof window === 'undefined') return false;
+    return window.sessionStorage.getItem(PermissionGuard.LOGIN_REDIRECT_FLAG) === 'true';
+  }
+
+  private markPendingLoginRedirect(): void {
+    if (typeof window === 'undefined') return;
+    window.sessionStorage.setItem(PermissionGuard.LOGIN_REDIRECT_FLAG, 'true');
+  }
+
+  private clearPendingLoginRedirect(): void {
+    if (typeof window === 'undefined') return;
+    window.sessionStorage.removeItem(PermissionGuard.LOGIN_REDIRECT_FLAG);
+  }
+
+  private buildRedirectUri(targetUrl?: string): string | undefined {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+    const base = window.location.origin;
+    if (!targetUrl || targetUrl === '/' || targetUrl === '') {
+      return base;
+    }
+    try {
+      return new URL(targetUrl, base).toString();
+    } catch {
+      return base;
+    }
+  }
+
+  private static readonly LOGIN_REDIRECT_FLAG = 'permission-guard-login-redirect';
 }

--- a/src/app/shared/data/data.service.ts
+++ b/src/app/shared/data/data.service.ts
@@ -192,6 +192,10 @@ export class DataService {
               requiredPermission: { module: 'user', level: 'read' },
             },
           ],
+          requiredPermission: [
+            { module: 'users', level: 'read' },
+            { module: 'user', level: 'read' },
+          ],
         },
       ],
     },
@@ -364,6 +368,10 @@ export class DataService {
               base: 'roles-permissions',
               requiredPermission: { module: 'user', level: 'read' },
             },
+          ],
+          requiredPermission: [
+            { module: 'users', level: 'read' },
+            { module: 'user', level: 'read' },
           ],
         },
       ],


### PR DESCRIPTION
## Summary
- hide the user management navigation entries when the current user lacks the related permissions
- update the permission guard to redirect unauthorized navigation attempts back through Keycloak login while preventing repeated redirects

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e514318d6c832f827c50873127e364